### PR TITLE
Cr129 adding test helper validation methods

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/time/DateTimeUtil.java
+++ b/src/main/java/uk/gov/ons/ctp/common/time/DateTimeUtil.java
@@ -5,6 +5,8 @@ import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import javax.xml.datatype.DatatypeConfigurationException;
@@ -18,6 +20,9 @@ import javax.xml.datatype.XMLGregorianCalendar;
 public class DateTimeUtil {
 
   public static final String DATE_FORMAT_IN_JSON = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+
+  private static DateTimeFormatter dateTimeFormatterForJson =
+      DateTimeFormatter.ofPattern(DATE_FORMAT_IN_JSON);
 
   private static final Logger log = LoggerFactory.getLogger(DateTimeUtil.class);
 
@@ -84,5 +89,14 @@ public class DateTimeUtil {
     }
 
     return result;
+  }
+
+  /**
+   * Create a String containing the current time formatted for use in JSON.
+   *
+   * @return a String formatted as per DateTimeUtil.DATE_FORMAT_IN_JSON.
+   */
+  public static String getCurrentDateTimeInJsonFormat() {
+    return dateTimeFormatterForJson.format(ZonedDateTime.now());
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/common/time/DateTimeUtilTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/time/DateTimeUtilTest.java
@@ -1,0 +1,16 @@
+package uk.gov.ons.ctp.common.time;
+
+import java.time.format.DateTimeFormatter;
+import org.junit.Test;
+
+public class DateTimeUtilTest {
+
+  @Test
+  public void testGetCurrentDateTimeInJsonFormat() {
+    String currentDateTime = DateTimeUtil.getCurrentDateTimeInJsonFormat();
+
+    String dateTimePattern = DateTimeUtil.DATE_FORMAT_IN_JSON;
+    DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(dateTimePattern);
+    dateTimeFormatter.parse(currentDateTime);
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/common/time/DateTimeUtilTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/time/DateTimeUtilTest.java
@@ -6,9 +6,11 @@ import org.junit.Test;
 public class DateTimeUtilTest {
 
   @Test
-  public void testGetCurrentDateTimeInJsonFormat() {
+  public void testGetCurrentDateTimeUsesCorrectFormat() {
+    // Invoke method under test, to get a string with the current datetime
     String currentDateTime = DateTimeUtil.getCurrentDateTimeInJsonFormat();
 
+    // Verify formatting of datatime by parsing it
     String dateTimePattern = DateTimeUtil.DATE_FORMAT_IN_JSON;
     DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(dateTimePattern);
     dateTimeFormatter.parse(currentDateTime);


### PR DESCRIPTION
# Motivation and Context
This pull request is for the addition of a utility method for getting the current time in a Json datetime format. The common service already has a constant to describe the format for the 'standard' datetime format.

# What has changed
Addition of get method and corresponding test case.

# How to test?
Run all unit tests.

# Links
This is part of CR129: https://collaborate2.ons.gov.uk/jira/browse/CR-129