### PR TITLE
GenericEvent and Header classes to be used by census-rh-service and c…

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/message/GenericEvent.java
+++ b/src/main/java/uk/gov/ons/ctp/common/message/GenericEvent.java
@@ -1,0 +1,13 @@
+package uk.gov.ons.ctp.common.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GenericEvent {
+
+  private Header event;
+}

--- a/src/main/java/uk/gov/ons/ctp/common/message/Header.java
+++ b/src/main/java/uk/gov/ons/ctp/common/message/Header.java
@@ -1,0 +1,17 @@
+package uk.gov.ons.ctp.common.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Header {
+
+  private String type;
+  private String source;
+  private String channel;
+  private String dateTime;
+  private String transactionId;
+}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required for CR-67 because it will need to use the GenericEvent and Header classes to help model and serialise the fulfilment requests, which come in from the Contact Centre, before sending them on to the RM system. The GenericEvent and Header classes have previously been created in the census-rh-service. This code change has copied them from there into this census-int-common-service, which both the census-rh-service and the census-contact-centre-service have a dependency on, so that CR-67 can use them within the census-contact-centre-service. Another pull request will be issued when they have been deleted from the census-rh-service later on.

# What has changed
The GenericEvent and Header classes have been added to the uk.gov.ons.ctp.common.message package within the census-int-common-service.

<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
This can only really be tested by deleting the GenericEvent and Header classes from the census-rh-service and then making sure that it still runs correctly. However, the change to the census-rh-service will need to be in a later pull request.

<!--- Describe in detail how you tested your changes. -->
