### PR TITLE
Cr 67 handle postal fulfilment requests

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/message/Header.java
+++ b/src/main/java/uk/gov/ons/ctp/common/message/Header.java
@@ -3,7 +3,6 @@ package uk.gov.ons.ctp.common.message;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.util.Date;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.ons.ctp.common.time.DateTimeUtil;

--- a/src/main/java/uk/gov/ons/ctp/common/message/Header.java
+++ b/src/main/java/uk/gov/ons/ctp/common/message/Header.java
@@ -1,8 +1,12 @@
 package uk.gov.ons.ctp.common.message;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.util.Date;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.ons.ctp.common.time.DateTimeUtil;
 
 @Data
 @NoArgsConstructor
@@ -12,6 +16,9 @@ public class Header {
   private String type;
   private String source;
   private String channel;
-  private String dateTime;
+
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DateTimeUtil.DATE_FORMAT_IN_JSON)
+  private Date dateTime;
+
   private String transactionId;
 }

--- a/src/main/java/uk/gov/ons/ctp/common/message/Header.java
+++ b/src/main/java/uk/gov/ons/ctp/common/message/Header.java
@@ -3,6 +3,7 @@ package uk.gov.ons.ctp.common.message;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.util.Date;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.ons.ctp.common.time.DateTimeUtil;
@@ -10,6 +11,7 @@ import uk.gov.ons.ctp.common.time.DateTimeUtil;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class Header {
 
   private String type;


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required because the Header class in the census-int-common-service, which is replacing the Header class from the census-rh-service, was not quite the same as the one it is replacing; the census-rh-service Header class had been updated to have the dateTime variable as a Date object rather than a String. 

# What has changed
The Header class, in the uk.gov.ons.ctp.common.message package within the census-int-common-service, has now been amended to have the dateTime variable as a Date object rather than a String. 

<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
This can only really be tested by making sure that the census-rh-service and still runs correctly e.g. that a message on the events exchange will go into the appropriate GCP bucket when the service is run, etc.

<!--- Describe in detail how you tested your changes. -->