### PR TITLE
change DateTimeUtil class to accept timestamps that end in Z aswell a…

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/time/DateTimeUtil.java
+++ b/src/main/java/uk/gov/ons/ctp/common/time/DateTimeUtil.java
@@ -19,7 +19,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
 // @CoverageIgnore
 public class DateTimeUtil {
 
-  public static final String DATE_FORMAT_IN_JSON = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+  public static final String DATE_FORMAT_IN_JSON = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
 
   private static DateTimeFormatter dateTimeFormatterForJson =
       DateTimeFormatter.ofPattern(DATE_FORMAT_IN_JSON);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required because the DateTimeUtil class in the census-int-common-service, which is used by the census-rh-service, was only accepting timestamp values that ended in +0000 but rejecting ones that ended in Z. Both types of timestamp value need to be accepted.

# What has changed
The DateTimeUtil class, in the uk.gov.ons.ctp.common.time package within the census-int-common-service, has now been amended to have a different value for the DATE_FORMAT_IN_JSON field. This should allow JSON to be accepted if it includes timestamps that end in Z (Zulu time) aswell as if it includes timestamps that end in +0000 (as it currently does).

<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
This can be tested by making sure that the census-rh-service still runs correctly e.g. that a message on the events exchange will go into the appropriate GCP bucket when the service is run, etc, rather than going into a dead letter queue. NB. It may be necessary to delete all your exchanges and queues from RabbitMQ to make sure that your dead letter queues do receive rejected messages first - otherwise, if the JSON is rejected, the message will simply disappear from RabbitMQ and nothing will appear in the bucket.

<!--- Describe in detail how you tested your changes. -->
