### PR TITLE
Cr86 retrieve case by caseId

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/time/DateTimeUtil.java
+++ b/src/main/java/uk/gov/ons/ctp/common/time/DateTimeUtil.java
@@ -5,6 +5,8 @@ import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
@@ -22,7 +24,7 @@ public class DateTimeUtil {
   public static final String DATE_FORMAT_IN_JSON = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 
   private static DateTimeFormatter dateTimeFormatterForJson =
-      DateTimeFormatter.ofPattern(DATE_FORMAT_IN_JSON);
+      DateTimeFormatter.ofPattern(DATE_FORMAT_IN_JSON).withZone(ZoneId.systemDefault());
 
   private static final Logger log = LoggerFactory.getLogger(DateTimeUtil.class);
 
@@ -98,5 +100,19 @@ public class DateTimeUtil {
    */
   public static String getCurrentDateTimeInJsonFormat() {
     return dateTimeFormatterForJson.format(ZonedDateTime.now());
+  }
+
+  public static String formatDate(Date date) {
+    return dateTimeFormatterForJson.format(date.toInstant());
+  }
+
+  /**
+   * Converts a date from a Date object to a LocalDateTime.
+   *
+   * @param date is the date to be converted.
+   * @return the same date value in LocalDateTime format.
+   */
+  public static LocalDateTime convertDateToLocalDateTime(Date date) {
+    return LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/common/time/DateTimeUtil.java
+++ b/src/main/java/uk/gov/ons/ctp/common/time/DateTimeUtil.java
@@ -21,7 +21,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
 // @CoverageIgnore
 public class DateTimeUtil {
 
-  public static final String DATE_FORMAT_IN_JSON = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+  public static final String DATE_FORMAT_IN_JSON = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
 
   private static DateTimeFormatter dateTimeFormatterForJson =
       DateTimeFormatter.ofPattern(DATE_FORMAT_IN_JSON).withZone(ZoneId.systemDefault());

--- a/src/main/java/uk/gov/ons/ctp/common/time/DateTimeUtil.java
+++ b/src/main/java/uk/gov/ons/ctp/common/time/DateTimeUtil.java
@@ -102,6 +102,11 @@ public class DateTimeUtil {
     return dateTimeFormatterForJson.format(ZonedDateTime.now());
   }
 
+  /**
+   * Format the supplied Date using the the standard JSON timestamp format (as defined in DATE_FORMAT_IN_JSON) 
+   * @param date is the date to convert to a String.
+   * @return a String containing the date formatted to the standard JSON format.
+   */
   public static String formatDate(Date date) {
     return dateTimeFormatterForJson.format(date.toInstant());
   }

--- a/src/main/java/uk/gov/ons/ctp/common/time/DateTimeUtil.java
+++ b/src/main/java/uk/gov/ons/ctp/common/time/DateTimeUtil.java
@@ -103,7 +103,9 @@ public class DateTimeUtil {
   }
 
   /**
-   * Format the supplied Date using the the standard JSON timestamp format (as defined in DATE_FORMAT_IN_JSON) 
+   * Format the supplied Date using the the standard JSON timestamp format (as defined in
+   * DATE_FORMAT_IN_JSON)
+   *
    * @param date is the date to convert to a String.
    * @return a String containing the date formatted to the standard JSON format.
    */

--- a/src/test/java/uk/gov/ons/ctp/common/time/DateTimeUtilTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/time/DateTimeUtilTest.java
@@ -25,7 +25,7 @@ public class DateTimeUtilTest {
 
   @Test
   public void testFormatDate() throws ParseException {
-    String testDateAsString = "2014-12-25T07:15:11.628+0000";
+    String testDateAsString = "2014-12-25T07:15:11.628Z";
 
     // Convert test date from string to a Date object
     SimpleDateFormat dateTimeFormatter = new SimpleDateFormat(DateTimeUtil.DATE_FORMAT_IN_JSON);

--- a/src/test/java/uk/gov/ons/ctp/common/time/DateTimeUtilTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/time/DateTimeUtilTest.java
@@ -1,12 +1,19 @@
 package uk.gov.ons.ctp.common.time;
 
+import static org.junit.Assert.assertEquals;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import org.junit.Test;
 
 public class DateTimeUtilTest {
 
   @Test
-  public void testGetCurrentDateTimeUsesCorrectFormat() {
+  public void testGetCurrentDateTimeInJsonFormatUsesCorrectFormat() {
     // Invoke method under test, to get a string with the current datetime
     String currentDateTime = DateTimeUtil.getCurrentDateTimeInJsonFormat();
 
@@ -14,5 +21,32 @@ public class DateTimeUtilTest {
     String dateTimePattern = DateTimeUtil.DATE_FORMAT_IN_JSON;
     DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(dateTimePattern);
     dateTimeFormatter.parse(currentDateTime);
+  }
+
+  @Test
+  public void testFormatDate() throws ParseException {
+    String testDateAsString = "2014-12-25T07:15:11.628+0000";
+
+    // Convert test date from string to a Date object
+    SimpleDateFormat dateTimeFormatter = new SimpleDateFormat(DateTimeUtil.DATE_FORMAT_IN_JSON);
+    Date testDateAsObject = dateTimeFormatter.parse(testDateAsString);
+
+    // Invoke method under test and confirm that the completed 'String -> Date -> String' cycle
+    // produces the same value that we started with
+    String testDateReconstituted = DateTimeUtil.formatDate(testDateAsObject);
+    assertEquals(testDateAsString, testDateReconstituted);
+  }
+
+  @Test
+  public void testConvertDateToLocalDateTime() {
+    // Get hold of the current date and invoke method under test
+    Date currentDate = new Date();
+    LocalDateTime asLocalDateTime = DateTimeUtil.convertDateToLocalDateTime(currentDate);
+
+    // Convert localDataTime back to a Date
+    Date dateFollowingConversion =
+        java.util.Date.from(asLocalDateTime.atZone(ZoneId.systemDefault()).toInstant());
+
+    assertEquals(currentDate, dateFollowingConversion);
   }
 }


### PR DESCRIPTION
# Motivation and Context
This change adds a couple of date time utility methods. These are needed  to support CR-86 (which adds get by caseId to Contact Centre).

# What has changed
Addition of 2 utility methods to DateTimeUtils.
Corresponding tests added.

# How to test?
Run the unit tests.

# Links
See CR-86: https://collaborate2.ons.gov.uk/jira/browse/CR-86