### PR TITLE
rename variable correctly - it is now named fulfilmentRequest instead…

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/event/model/FulfilmentPayload.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/FulfilmentPayload.java
@@ -9,5 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class FulfilmentPayload {
 
-  private FulfilmentRequest collectionCase = new FulfilmentRequest();
+  private FulfilmentRequest fulfilmentRequest = new FulfilmentRequest();
 }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required because a variable named collectionCase should have been named fulfilmentRequest instead

# What has changed
The following class now contains a variable named fulfilmentRequest:

uk.gov.ons.ctp.common.event.model.FulfilmentPayload


<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
N/A