### PR TITLE
add individualCaseId field to the Fulfilment Request class

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/event/model/FulfilmentRequest.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/FulfilmentRequest.java
@@ -11,6 +11,7 @@ public class FulfilmentRequest {
 
   private String fulfilmentCode;
   private String caseId;
+  private String individualCaseId;
   private Address address = new Address();
   private Contact contact = new Contact();
 }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required because an individualCaseId will sometimes need to be sent to RM as part of a FulfilmentRequest

# What has changed
The following class has changed to include the individualCaseId field:

src/main/java/uk/gov/ons/ctp/common/event/model/FulfilmentRequest.java

<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
N/A