### PR TITLE
CR70 Adding DTO's to hold refusal event

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/event/model/CollectionCaseCompact.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/CollectionCaseCompact.java
@@ -1,0 +1,14 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CollectionCaseCompact {
+
+  private UUID id;
+}

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalDetails.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalDetails.java
@@ -1,0 +1,17 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RespondentRefusalDetails {
+
+  private String type;
+  private String report;
+  private String agentId;
+  private CollectionCaseCompact collectionCase = new CollectionCaseCompact();
+  private Contact contact = new Contact();
+}

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalEvent.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalEvent.java
@@ -1,0 +1,15 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class RespondentRefusalEvent extends GenericEvent {
+
+  private RespondentRefusalPayload payload = new RespondentRefusalPayload();
+}

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalPayload.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalPayload.java
@@ -1,0 +1,13 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RespondentRefusalPayload {
+
+  private RespondentRefusalDetails refusal = new RespondentRefusalDetails();
+}


### PR DESCRIPTION
# Motivation and Context
Adding DTO's to hold the event that is published for respondent refusal

# Links
See: https://collaborate2.ons.gov.uk/jira/browse/CR-70

Also see the example message for the 'event.respondent.refusal' binding in the event dictionary: https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=CATD&title=Response+Management+Event+Dictionary