### PR TITLE
CR70 Adding address details to the refusal event

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/event/model/AddressCompact.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/AddressCompact.java
@@ -1,0 +1,18 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddressCompact {
+
+  private String addressLine1;
+  private String addressLine2;
+  private String addressLine3;
+  private String townName;
+  private String postcode;
+  private String region; // E, W or N
+}

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalDetails.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalDetails.java
@@ -14,4 +14,5 @@ public class RespondentRefusalDetails {
   private String agentId;
   private CollectionCaseCompact collectionCase = new CollectionCaseCompact();
   private Contact contact = new Contact();
+  private AddressCompact address = new AddressCompact();
 }


### PR DESCRIPTION
# Motivation and Context
Adding address fields to the refusal event.

# Links
See: https://collaborate2.ons.gov.uk/jira/browse/CR-70

Also see the updated example message for the 'event.respondent.refusal' binding in the event dictionary. This now has the address fields: https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=CATD&title=Response+Management+Event+Dictionary
