### PR TITLE
CR-120 Respondent Auth event model classes

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentAuthenticatedEvent.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentAuthenticatedEvent.java
@@ -1,0 +1,13 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RespondentAuthenticatedEvent extends GenericEvent {
+
+  private RespondentAuthenticatedPayload payload = new RespondentAuthenticatedPayload();
+}

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentAuthenticatedPayload.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentAuthenticatedPayload.java
@@ -1,0 +1,13 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RespondentAuthenticatedPayload {
+
+  private RespondentAuthenticatedResponse response = new RespondentAuthenticatedResponse();
+}

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentAuthenticatedResponse.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentAuthenticatedResponse.java
@@ -1,0 +1,17 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RespondentAuthenticatedResponse {
+
+  private String questionnaireId;
+  private UUID caseId;
+}


### PR DESCRIPTION
# Motivation and Context
Respondent Authentication event model classes following pattern used by other event messages.
Classes required in common to implement functionality requested in [CR-120](https://collaborate2.ons.gov.uk/jira/browse/CR-120) 

# What has changed
RespondentAuthenticatedEvent, RespondentAuthenticatedPayload and RespondentAuthenticatedResponse added.

# How to test?
Tested in unit tests in census-rh-service repository which imports these classes for use. 
