### PR TITLE
Added unit tests to cover event sending. Also removed automatic creat…

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
@@ -64,41 +64,41 @@ public class EventPublisher {
   public String sendEvent(String routingKey, EventPayload payload) throws CTPException {
 
     GenericEvent genericEvent = null;
-    Header header = null;
     if (payload instanceof SurveyLaunchedResponse) {
-      header = buildHeader(EventType.SURVEY_LAUNCHED);
-      genericEvent = new SurveyLaunchedEvent();
-      genericEvent.setEvent(header);
-      ((SurveyLaunchedEvent) genericEvent)
-          .getPayload()
-          .setResponse((SurveyLaunchedResponse) payload);
+      SurveyLaunchedEvent event = new SurveyLaunchedEvent();
+      event.setEvent(buildHeader(EventType.SURVEY_LAUNCHED));
+      event.getPayload().setResponse((SurveyLaunchedResponse) payload);
+      genericEvent = event;
+
     } else if (payload instanceof RespondentAuthenticatedResponse) {
-      header = buildHeader(EventType.RESPONDENT_AUTHENTICATED);
-      genericEvent = new RespondentAuthenticatedEvent();
-      genericEvent.setEvent(header);
-      ((RespondentAuthenticatedEvent) genericEvent)
-          .getPayload()
-          .setResponse((RespondentAuthenticatedResponse) payload);
+      RespondentAuthenticatedEvent event = new RespondentAuthenticatedEvent();
+      event.setEvent(buildHeader(EventType.RESPONDENT_AUTHENTICATED));
+      event.getPayload().setResponse((RespondentAuthenticatedResponse) payload);
+      genericEvent = event;
+
     } else if (payload instanceof FulfilmentRequest) {
-      header = buildHeader(EventType.FULFILMENT_REQUESTED);
-      genericEvent = new FulfilmentRequestedEvent();
-      genericEvent.setEvent(header);
+      FulfilmentRequestedEvent event = new FulfilmentRequestedEvent();
+      event.setEvent(buildHeader(EventType.FULFILMENT_REQUESTED));
       FulfilmentPayload fulfilmentPayload = new FulfilmentPayload((FulfilmentRequest) payload);
-      ((FulfilmentRequestedEvent) genericEvent).setPayload(fulfilmentPayload);
+      event.setPayload(fulfilmentPayload);
+      genericEvent = event;
+
     } else if (payload instanceof RespondentRefusalDetails) {
-      header = buildHeader(EventType.REFUSAL_RECEIVED);
-      genericEvent = new RespondentRefusalEvent();
-      genericEvent.setEvent(header);
+      RespondentRefusalEvent event = new RespondentRefusalEvent();
+      event.setEvent(buildHeader(EventType.REFUSAL_RECEIVED));
       RespondentRefusalPayload respondentRefusalPayload =
           new RespondentRefusalPayload((RespondentRefusalDetails) payload);
-      ((RespondentRefusalEvent) genericEvent).setPayload(respondentRefusalPayload);
+      event.setPayload(respondentRefusalPayload);
+      genericEvent = event;
+
     } else {
       log.error(payload.getClass().getName() + " not supported");
       throw new CTPException(
           CTPException.Fault.SYSTEM_ERROR, payload.getClass().getName() + " not supported");
     }
+
     template.convertAndSend(routingKey, genericEvent);
-    return header.getTransactionId();
+    return genericEvent.getEvent().getTransactionId();
   }
 
   private static Header buildHeader(EventType type) {

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/FulfilmentPayload.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/FulfilmentPayload.java
@@ -9,5 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class FulfilmentPayload {
 
-  private FulfilmentRequest fulfilmentRequest = new FulfilmentRequest();
+  private FulfilmentRequest fulfilmentRequest;
 }

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/FulfilmentRequest.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/FulfilmentRequest.java
@@ -7,11 +7,11 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class FulfilmentRequest {
+public class FulfilmentRequest implements EventPayload {
 
   private String fulfilmentCode;
   private String caseId;
   private String individualCaseId;
-  private Address address = new Address();
-  private Contact contact = new Contact();
+  private Address address;
+  private Contact contact;
 }

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/FulfilmentRequestedEvent.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/FulfilmentRequestedEvent.java
@@ -9,5 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class FulfilmentRequestedEvent extends GenericEvent {
 
-  private FulfilmentPayload payload = new FulfilmentPayload();
+  private FulfilmentPayload payload;
 }

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalDetails.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalDetails.java
@@ -7,12 +7,12 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class RespondentRefusalDetails {
+public class RespondentRefusalDetails implements EventPayload {
 
   private String type;
   private String report;
   private String agentId;
-  private CollectionCaseCompact collectionCase = new CollectionCaseCompact();
-  private Contact contact = new Contact();
-  private AddressCompact address = new AddressCompact();
+  private CollectionCaseCompact collectionCase;
+  private Contact contact;
+  private AddressCompact address;
 }

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalEvent.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalEvent.java
@@ -11,5 +11,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class RespondentRefusalEvent extends GenericEvent {
 
-  private RespondentRefusalPayload payload = new RespondentRefusalPayload();
+  private RespondentRefusalPayload payload;
 }

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalPayload.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalPayload.java
@@ -9,5 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class RespondentRefusalPayload {
 
-  private RespondentRefusalDetails refusal = new RespondentRefusalDetails();
+  private RespondentRefusalDetails refusal;
 }

--- a/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTest.java
@@ -3,6 +3,7 @@ package uk.gov.ons.ctp.common.event;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
@@ -21,22 +22,26 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.event.model.EventPayload;
+import uk.gov.ons.ctp.common.event.model.FulfilmentRequest;
+import uk.gov.ons.ctp.common.event.model.FulfilmentRequestedEvent;
 import uk.gov.ons.ctp.common.event.model.RespondentAuthenticatedEvent;
 import uk.gov.ons.ctp.common.event.model.RespondentAuthenticatedResponse;
+import uk.gov.ons.ctp.common.event.model.RespondentRefusalDetails;
+import uk.gov.ons.ctp.common.event.model.RespondentRefusalEvent;
 import uk.gov.ons.ctp.common.event.model.SurveyLaunchedEvent;
 import uk.gov.ons.ctp.common.event.model.SurveyLaunchedResponse;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EventPublisherTest {
 
-  private static final String ROUTEING_KEY = "whereAreWeRoutingThis";
+  private static final String ROUTING_KEY = "whereAreWeRoutingThis";
   private static final UUID CASE_ID = UUID.fromString("dc4477d1-dd3f-4c69-b181-7ff725dc9fa4");
   private static final String QUESTIONNAIRE_ID = "1110000009";
 
   @InjectMocks private EventPublisher eventPublisher;
   @Mock private RabbitTemplate template;
 
-  /** Test event message with SurveyLaunchedResponse pay load */
+  /** Test event message with SurveyLaunchedResponse payload */
   @Test
   public void sendEventSurveyLaunchedPayload() throws Exception {
 
@@ -46,12 +51,12 @@ public class EventPublisherTest {
     ArgumentCaptor<SurveyLaunchedEvent> eventCapture =
         ArgumentCaptor.forClass(SurveyLaunchedEvent.class);
 
-    String trandactionId = eventPublisher.sendEvent(ROUTEING_KEY, surveyLaunchedResponse);
+    String transactionId = eventPublisher.sendEvent(ROUTING_KEY, surveyLaunchedResponse);
 
-    verify(template, times(1)).convertAndSend(eq(ROUTEING_KEY), eventCapture.capture());
+    verify(template, times(1)).convertAndSend(eq(ROUTING_KEY), eventCapture.capture());
     SurveyLaunchedEvent event = eventCapture.getValue();
 
-    assertEquals(event.getEvent().getTransactionId(), trandactionId);
+    assertEquals(event.getEvent().getTransactionId(), transactionId);
     assertThat(UUID.fromString(event.getEvent().getTransactionId()), instanceOf(UUID.class));
     assertEquals(EventPublisher.EventType.SURVEY_LAUNCHED.toString(), event.getEvent().getType());
     assertEquals(
@@ -63,7 +68,7 @@ public class EventPublisherTest {
     assertEquals(QUESTIONNAIRE_ID, event.getPayload().getResponse().getQuestionnaireId());
   }
 
-  /** Test event message with RespondentAuthenticatedResponse pay load */
+  /** Test event message with RespondentAuthenticatedResponse payload */
   @Test
   public void sendEventRespondentAuthenticatedPayload() throws Exception {
 
@@ -76,12 +81,12 @@ public class EventPublisherTest {
     ArgumentCaptor<RespondentAuthenticatedEvent> eventCapture =
         ArgumentCaptor.forClass(RespondentAuthenticatedEvent.class);
 
-    String trandactionId = eventPublisher.sendEvent(ROUTEING_KEY, respondentAuthenticatedResponse);
+    String transactionId = eventPublisher.sendEvent(ROUTING_KEY, respondentAuthenticatedResponse);
 
-    verify(template, times(1)).convertAndSend(eq(ROUTEING_KEY), eventCapture.capture());
+    verify(template, times(1)).convertAndSend(eq(ROUTING_KEY), eventCapture.capture());
     RespondentAuthenticatedEvent event = eventCapture.getValue();
 
-    assertEquals(event.getEvent().getTransactionId(), trandactionId);
+    assertEquals(event.getEvent().getTransactionId(), transactionId);
     assertThat(UUID.fromString(event.getEvent().getTransactionId()), instanceOf(UUID.class));
     assertEquals(
         EventPublisher.EventType.RESPONDENT_AUTHENTICATED.toString(), event.getEvent().getType());
@@ -96,6 +101,62 @@ public class EventPublisherTest {
     assertEquals(QUESTIONNAIRE_ID, event.getPayload().getResponse().getQuestionnaireId());
   }
 
+  /** Test event message with FulfilmentRequest payload */
+  @Test
+  public void sendEventFulfilmentRequestPayload() throws Exception {
+
+    // Build fulfilment
+    FulfilmentRequest fulfilmentRequest = new FulfilmentRequest();
+    fulfilmentRequest.setCaseId("id-123");
+
+    ArgumentCaptor<FulfilmentRequestedEvent> eventCapture =
+        ArgumentCaptor.forClass(FulfilmentRequestedEvent.class);
+
+    String transactionId = eventPublisher.sendEvent(ROUTING_KEY, fulfilmentRequest);
+
+    verify(template, times(1)).convertAndSend(eq(ROUTING_KEY), eventCapture.capture());
+    FulfilmentRequestedEvent event = eventCapture.getValue();
+
+    assertEquals(event.getEvent().getTransactionId(), transactionId);
+    assertThat(UUID.fromString(event.getEvent().getTransactionId()), instanceOf(UUID.class));
+    assertEquals(
+        EventPublisher.EventType.FULFILMENT_REQUESTED.toString(), event.getEvent().getType());
+    assertEquals(
+        EventPublisher.EventType.FULFILMENT_REQUESTED.getSource(), event.getEvent().getSource());
+    assertEquals(
+        EventPublisher.EventType.FULFILMENT_REQUESTED.getChannel(), event.getEvent().getChannel());
+    assertNotNull(event.getEvent().getDateTime());
+    assertEquals("id-123", event.getPayload().getFulfilmentRequest().getCaseId());
+  }
+
+  /** Test event message with RespondentRefusalDetails payload */
+  @Test
+  public void sendEventRespondentRefusalDetailsPayload() throws Exception {
+
+    // Build fulfilment
+    RespondentRefusalDetails respondentRefusalDetails = new RespondentRefusalDetails();
+    respondentRefusalDetails.setAgentId("x1");
+
+    ArgumentCaptor<RespondentRefusalEvent> eventCapture =
+        ArgumentCaptor.forClass(RespondentRefusalEvent.class);
+
+    String transactionId = eventPublisher.sendEvent(ROUTING_KEY, respondentRefusalDetails);
+
+    verify(template, times(1)).convertAndSend(eq(ROUTING_KEY), eventCapture.capture());
+    RespondentRefusalEvent event = eventCapture.getValue();
+
+    assertEquals(event.getEvent().getTransactionId(), transactionId);
+    assertThat(UUID.fromString(event.getEvent().getTransactionId()), instanceOf(UUID.class));
+    assertEquals(EventPublisher.EventType.REFUSAL_RECEIVED.toString(), event.getEvent().getType());
+    assertEquals(
+        EventPublisher.EventType.REFUSAL_RECEIVED.getSource(), event.getEvent().getSource());
+    assertEquals(
+        EventPublisher.EventType.REFUSAL_RECEIVED.getChannel(), event.getEvent().getChannel());
+    assertNotNull(event.getEvent().getDateTime());
+    assertEquals(
+        respondentRefusalDetails.getAgentId(), event.getPayload().getRefusal().getAgentId());
+  }
+
   /** Test build of Respondent Authenticated event message with wrong pay load */
   @Test
   public void sendEventRespondentAuthenticatedWrongPayload() {
@@ -103,7 +164,7 @@ public class EventPublisherTest {
     boolean exceptionThrown = false;
 
     try {
-      eventPublisher.sendEvent(ROUTEING_KEY, Mockito.mock(EventPayload.class));
+      eventPublisher.sendEvent(ROUTING_KEY, Mockito.mock(EventPayload.class));
     } catch (CTPException e) {
       exceptionThrown = true;
       assertThat(e.getMessage(), containsString("not supported"));


### PR DESCRIPTION
…ion of child objects

# Motivation and Context
Expanded event sending to also do refusals and fulfilments.
Added corresponding unit tests.
Also cleaned up DTO objects for refusals and fulfilments so that they don't automatically create child objects. 

# How to test?
Run the unit tests.

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-70