### PR TITLE
Cr314 report not found errors as 404

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/error/RestExceptionHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/common/error/RestExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ResponseStatusException;
 
 /** Rest Exception Handler */
 @ControllerAdvice
@@ -58,11 +59,26 @@ public class RestExceptionHandler {
         status = HttpStatus.INTERNAL_SERVER_ERROR;
         break;
       default:
-        status = HttpStatus.I_AM_A_TEAPOT;
+        status = HttpStatus.INTERNAL_SERVER_ERROR;
         break;
     }
 
     return new ResponseEntity<>(exception, status);
+  }
+
+  /**
+   * Handler for ResponseStatusException.
+   *
+   * @param exception is the underlying exception.
+   * @return ResponseEntity containing exception details.
+   */
+  @ExceptionHandler(ResponseStatusException.class)
+  public ResponseEntity<?> handleResponseStatusException(ResponseStatusException exception) {
+    log.with("fault", exception.getStatus())
+        .with("exception_message", exception.getMessage())
+        .error("Uncaught ResponseStatusException", exception);
+
+    return new ResponseEntity<>(exception, exception.getStatus());
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
@@ -59,7 +59,7 @@ public class EventPublisher {
    * @param routingKey message routing key for event
    * @param payload message payload for event
    * @return String UUID transaction Id for event
-   * @throws CTPException
+   * @throws CTPException if a failure was detected.
    */
   public String sendEvent(String routingKey, EventPayload payload) throws CTPException {
 

--- a/src/test/java/uk/gov/ons/ctp/common/rest/RestClientTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/rest/RestClientTest.java
@@ -15,7 +15,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -225,7 +224,7 @@ public class RestClientTest {
   }
 
   /** A test */
-  @Test
+  @Test(expected = ResponseStatusException.class)
   public void testGetResourcesNoContent() {
     RestClient restClient = new RestClient();
     RestTemplate restTemplate = restClient.getRestTemplate();
@@ -236,14 +235,11 @@ public class RestClientTest {
         .andExpect(method(HttpMethod.GET))
         .andRespond(withStatus(HttpStatus.NO_CONTENT));
 
-    List<FakeDTO> fakeDTOs = restClient.getResources("/hotels", FakeDTO[].class);
-    assertTrue(fakeDTOs != null);
-    assertTrue(fakeDTOs.size() == 0);
-    mockServer.verify();
+    restClient.getResources("/hotels", FakeDTO[].class);
   }
 
   /** A test */
-  @Test(expected = RestClientException.class)
+  @Test(expected = ResponseStatusException.class)
   public void testGetResourcesReallyNotOk() {
     RestClientConfig config =
         RestClientConfig.builder().scheme("http").host("localhost").port("8080").build();
@@ -260,7 +256,7 @@ public class RestClientTest {
   }
 
   /** A test */
-  @Test(expected = RestClientException.class)
+  @Test(expected = ResponseStatusException.class)
   public void testGetResourcesUnauthorized() {
     RestClientConfig config =
         RestClientConfig.builder().scheme("http").host("localhost").port("8080").build();


### PR DESCRIPTION
# Motivation and Context
This CR fixes the bug reported by Serco. 
404 errors were being reported in the body of a http response but the status code for the http request itself would be 500 instead of 404.

# What has changed
This pull request covers 3 fixes:
1) No top level exception catching for the exceptions thrown during rest calls. So the, say, 404 status got mapped to a generic 500.
2) RestClient method for getResources (not getResource method) had error handling that didn't match a real server. The getResources() is now delegating to getResource().
3) Test failure due to the getResource handling of 204 errors. Now throwing exception for null content, just as per original RestClient code.

# How to test?
Run unit tests and manually hit the endpoints of the Contact Centre.
I've tested this against the fake case service and have been able to use this to simulate 404 errors in the case service and confirm that they are reported with the correct status code in the http response.
