### PR TITLE
CR-550 Validation failures now logging as warnings instead of errors

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/error/RestExceptionHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/common/error/RestExceptionHandler.java
@@ -199,7 +199,7 @@ public class RestExceptionHandler {
 
     log.with("validation_errors", errors)
         .with("source_message", ex.getMessage())
-        .error("Unhandled BindException", ex);
+        .warn("Unhandled BindException", ex);
     CTPException ourException =
         new CTPException(CTPException.Fault.VALIDATION_FAILED, ex.getMessage());
     return new ResponseEntity<>(ourException, HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
# Motivation and Context
This changes reduces the amount of noise in the logs. The Contact Centre logs contain many errors which are reporting that CC has been invoked with an invalid postcode. This change reduces the logging level of validation failures from error to warnings. 

# What has changed
Logging level in RestExceptionHandler.

# How to test?
Run the CC & RH tests (pass with this modified common service)

# Links
See: https://collaborate2.ons.gov.uk/jira/browse/CR-550