### PR TITLE
remove dependencies on spring-integration-amqp and spring-rabbit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,19 +110,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- <dependency> <groupId>net.sourceforge.cobertura</groupId> <artifactId>cobertura</artifactId> 
-      </dependency> -->
-
-    <dependency>
-      <groupId>org.springframework.integration</groupId>
-      <artifactId>spring-integration-amqp</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.amqp</groupId>
-      <artifactId>spring-rabbit</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-parameter-names</artifactId>


### PR DESCRIPTION
The dependencies on spring-integration-amqp and spring-rabbit have been removed from census-int-common-service so that, from now on, anything that has a dependency on census-int-common-service will not need to either create a RabbitTemplate, and so on, or otherwise exclude 
spring-integration-amqp and spring-rabbit in their pom file.