### PR TITLE
CR-000 added mapUtil to ease field service map management plus cleanups

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/collection/MapUtil.java
+++ b/src/main/java/uk/gov/ons/ctp/common/collection/MapUtil.java
@@ -4,23 +4,23 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 public interface MapUtil {
-  
+
   /**
-   * Using the supplied lambda, put the value it provides into the map
-   * IF the value is non null
-   * AND the obtaining of the value does not yield a NullPointerException (allows for youTo.getPossibleNullFirst().beforeUsingValue()
-   * ELSE do not put an entry into the map with that key
-   * 
-   * NOTE: the provided lambda cannot throw checked exceptions, so if your required lambda declares
-   * such, extract that into a prior step before calling this method.
-   * 
+   * Using the supplied lambda, put the value it provides into the map IF the value is non null AND
+   * the obtaining of the value does not yield a NullPointerException (allows for
+   * youTo.getPossibleNullFirst().beforeUsingValue() ELSE do not put an entry into the map with that
+   * key
+   *
+   * <p>NOTE: the provided lambda cannot throw checked exceptions, so if your required lambda
+   * declares such, extract that into a prior step before calling this method.
+   *
    * @param map the map to put into
    * @param key the key for the value in the map
    * @param supplier a lambda whose result will be put into the map against the key
    */
-  static <K,V> void putIfNotNull(Map<K, V> map, K key, Supplier<V> supplier) {
+  static <K, V> void putIfNotNull(Map<K, V> map, K key, Supplier<V> supplier) {
     try {
-      map.computeIfAbsent(key, (v) -> supplier.get()); 
+      map.computeIfAbsent(key, (v) -> supplier.get());
     } catch (NullPointerException e) {
       // do nothing - the whole point
     }

--- a/src/main/java/uk/gov/ons/ctp/common/collection/MapUtil.java
+++ b/src/main/java/uk/gov/ons/ctp/common/collection/MapUtil.java
@@ -1,0 +1,28 @@
+package uk.gov.ons.ctp.common.collection;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+public interface MapUtil {
+  
+  /**
+   * Using the supplied lambda, put the value it provides into the map
+   * IF the value is non null
+   * AND the obtaining of the value does not yield a NullPointerException (allows for youTo.getPossibleNullFirst().beforeUsingValue()
+   * ELSE do not put an entry into the map with that key
+   * 
+   * NOTE: the provided lambda cannot throw checked exceptions, so if your required lambda declares
+   * such, extract that into a prior step before calling this method.
+   * 
+   * @param map the map to put into
+   * @param key the key for the value in the map
+   * @param supplier a lambda whose result will be put into the map against the key
+   */
+  static <K,V> void putIfNotNull(Map<K, V> map, K key, Supplier<V> supplier) {
+    try {
+      map.computeIfAbsent(key, (v) -> supplier.get()); 
+    } catch (NullPointerException e) {
+      // do nothing - the whole point
+    }
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/common/error/InvalidRequestException.java
+++ b/src/main/java/uk/gov/ons/ctp/common/error/InvalidRequestException.java
@@ -7,6 +7,10 @@ import org.springframework.validation.Errors;
 // @CoverageIgnore
 public class InvalidRequestException extends Exception {
 
+  /**
+   * 
+   */
+  private static final long serialVersionUID = -3708136528897081539L;
   private Errors errors;
   private String sourceMessage = "Invalid Request ";
 

--- a/src/main/java/uk/gov/ons/ctp/common/error/InvalidRequestException.java
+++ b/src/main/java/uk/gov/ons/ctp/common/error/InvalidRequestException.java
@@ -7,10 +7,9 @@ import org.springframework.validation.Errors;
 // @CoverageIgnore
 public class InvalidRequestException extends Exception {
 
-  /**
-   * 
-   */
+  /** */
   private static final long serialVersionUID = -3708136528897081539L;
+
   private Errors errors;
   private String sourceMessage = "Invalid Request ";
 

--- a/src/main/java/uk/gov/ons/ctp/common/retry/CTPRetryPolicy.java
+++ b/src/main/java/uk/gov/ons/ctp/common/retry/CTPRetryPolicy.java
@@ -22,6 +22,11 @@ import org.springframework.util.ClassUtils;
  */
 public class CTPRetryPolicy implements RetryPolicy {
 
+  /**
+   * 
+   */
+  private static final long serialVersionUID = -4678565949872055319L;
+
   private static final Logger log = LoggerFactory.getLogger(CTPRetryPolicy.class);
 
   private static final int DEFAULT_MAX_ATTEMPTS = 3;
@@ -128,6 +133,11 @@ public class CTPRetryPolicy implements RetryPolicy {
 
   /** To mirror implementation in SimpleRetryPolicy */
   private static class CTPRetryContext extends RetryContextSupport {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = -8133635092645664091L;
+
     /**
      * Method to mirror implementation in SimpleRetryPolicy
      *

--- a/src/main/java/uk/gov/ons/ctp/common/retry/CTPRetryPolicy.java
+++ b/src/main/java/uk/gov/ons/ctp/common/retry/CTPRetryPolicy.java
@@ -22,9 +22,7 @@ import org.springframework.util.ClassUtils;
  */
 public class CTPRetryPolicy implements RetryPolicy {
 
-  /**
-   * 
-   */
+  /** */
   private static final long serialVersionUID = -4678565949872055319L;
 
   private static final Logger log = LoggerFactory.getLogger(CTPRetryPolicy.class);
@@ -133,9 +131,7 @@ public class CTPRetryPolicy implements RetryPolicy {
 
   /** To mirror implementation in SimpleRetryPolicy */
   private static class CTPRetryContext extends RetryContextSupport {
-    /**
-     * 
-     */
+    /** */
     private static final long serialVersionUID = -8133635092645664091L;
 
     /**

--- a/src/main/java/uk/gov/ons/ctp/common/retry/CTPUnknownHostRetryPolicy.java
+++ b/src/main/java/uk/gov/ons/ctp/common/retry/CTPUnknownHostRetryPolicy.java
@@ -22,6 +22,11 @@ import org.springframework.util.ClassUtils;
  */
 public class CTPUnknownHostRetryPolicy implements RetryPolicy {
 
+  /**
+   * 
+   */
+  private static final long serialVersionUID = -7771272230936795889L;
+
   private static final Logger log = LoggerFactory.getLogger(CTPUnknownHostRetryPolicy.class);
 
   private static final int DEFAULT_MAX_ATTEMPTS = 3;
@@ -163,6 +168,11 @@ public class CTPUnknownHostRetryPolicy implements RetryPolicy {
 
   /** To mirror implementation in SimpleRetryPolicy */
   private static class CTPRetryContext extends RetryContextSupport {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 7264213745244015857L;
+
     /**
      * Method to mirror implementation in SimpleRetryPolicy
      *

--- a/src/main/java/uk/gov/ons/ctp/common/retry/CTPUnknownHostRetryPolicy.java
+++ b/src/main/java/uk/gov/ons/ctp/common/retry/CTPUnknownHostRetryPolicy.java
@@ -22,9 +22,7 @@ import org.springframework.util.ClassUtils;
  */
 public class CTPUnknownHostRetryPolicy implements RetryPolicy {
 
-  /**
-   * 
-   */
+  /** */
   private static final long serialVersionUID = -7771272230936795889L;
 
   private static final Logger log = LoggerFactory.getLogger(CTPUnknownHostRetryPolicy.class);
@@ -168,9 +166,7 @@ public class CTPUnknownHostRetryPolicy implements RetryPolicy {
 
   /** To mirror implementation in SimpleRetryPolicy */
   private static class CTPRetryContext extends RetryContextSupport {
-    /**
-     * 
-     */
+    /** */
     private static final long serialVersionUID = 7264213745244015857L;
 
     /**

--- a/src/test/java/uk/gov/ons/ctp/common/distributed/DistributedLockManagerRedissonImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/distributed/DistributedLockManagerRedissonImplTest.java
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 

--- a/src/test/java/uk/gov/ons/ctp/common/rest/RestUtilityTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/rest/RestUtilityTest.java
@@ -23,7 +23,8 @@ public class RestUtilityTest {
     String authorizationHeader = httpEntity.getHeaders().getFirst("Authorization");
     String base64UserPassword = StringUtils.substringAfter(authorizationHeader, "Basic ");
     String usernamePassword =
-        new String(Base64.getDecoder().decode(base64UserPassword.getBytes()), StandardCharsets.US_ASCII);
+        new String(
+            Base64.getDecoder().decode(base64UserPassword.getBytes()), StandardCharsets.US_ASCII);
     assertEquals(usernamePassword, "user:password");
   }
 
@@ -51,7 +52,8 @@ public class RestUtilityTest {
     String authorizationHeader = httpEntity.getHeaders().getFirst("Authorization");
     String base64UserPassword = StringUtils.substringAfter(authorizationHeader, "Basic ");
     String usernamePassword =
-        new String(Base64.getDecoder().decode(base64UserPassword.getBytes()), StandardCharsets.US_ASCII);
+        new String(
+            Base64.getDecoder().decode(base64UserPassword.getBytes()), StandardCharsets.US_ASCII);
     assertEquals(usernamePassword, "user:password");
   }
 

--- a/src/test/java/uk/gov/ons/ctp/common/rest/RestUtilityTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/rest/RestUtilityTest.java
@@ -5,10 +5,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.springframework.http.HttpEntity;
-import org.springframework.security.crypto.codec.Base64;
 
 public class RestUtilityTest {
 
@@ -23,7 +23,7 @@ public class RestUtilityTest {
     String authorizationHeader = httpEntity.getHeaders().getFirst("Authorization");
     String base64UserPassword = StringUtils.substringAfter(authorizationHeader, "Basic ");
     String usernamePassword =
-        new String(Base64.decode(base64UserPassword.getBytes()), StandardCharsets.US_ASCII);
+        new String(Base64.getDecoder().decode(base64UserPassword.getBytes()), StandardCharsets.US_ASCII);
     assertEquals(usernamePassword, "user:password");
   }
 
@@ -51,7 +51,7 @@ public class RestUtilityTest {
     String authorizationHeader = httpEntity.getHeaders().getFirst("Authorization");
     String base64UserPassword = StringUtils.substringAfter(authorizationHeader, "Basic ");
     String usernamePassword =
-        new String(Base64.decode(base64UserPassword.getBytes()), StandardCharsets.US_ASCII);
+        new String(Base64.getDecoder().decode(base64UserPassword.getBytes()), StandardCharsets.US_ASCII);
     assertEquals(usernamePassword, "user:password");
   }
 

--- a/src/test/java/uk/ons/ctp/common/collection/MapUtilTest.java
+++ b/src/test/java/uk/ons/ctp/common/collection/MapUtilTest.java
@@ -1,0 +1,46 @@
+package uk.ons.ctp.common.collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import lombok.Data;
+import uk.gov.ons.ctp.common.collection.MapUtil;
+
+public class MapUtilTest {
+
+  public Map<String, String> testMap = new HashMap<>();
+  
+  @Test
+  public void putIfNotNullWhenNotNull() {
+    MapUtil.putIfNotNull(testMap, "notNull", () -> "notNullValue");
+    assertEquals(testMap.get("notNull"), "notNullValue");
+  }
+
+  @Test
+  public void putIfNotNullWhenDirectlyNull() {
+    MapUtil.putIfNotNull(testMap, "directlyNull", () -> null);
+    assertFalse(testMap.containsKey("directlyNull"));
+  }
+
+  @Test
+  public void putIfNotNullWhenInDirectlyNull() {
+    Foo foo = new Foo();
+    MapUtil.putIfNotNull(testMap, "inDirectlyNull", () -> foo.getName());
+    assertFalse(testMap.containsKey("inDirectlyNull"));
+  }
+  
+  @Test
+  public void putIfNotNullWhenNullPointer() {
+    Foo foo = new Foo();
+    MapUtil.putIfNotNull(testMap, "inDirectlyNull", () -> foo.getChild().getName());
+    assertFalse(testMap.containsKey("inDirectlyNull"));
+  }
+
+  @Data
+  class Foo {
+    String name;
+    Foo child;
+  }
+}

--- a/src/test/java/uk/ons/ctp/common/collection/MapUtilTest.java
+++ b/src/test/java/uk/ons/ctp/common/collection/MapUtilTest.java
@@ -2,16 +2,17 @@ package uk.ons.ctp.common.collection;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Test;
 import lombok.Data;
+import org.junit.Test;
 import uk.gov.ons.ctp.common.collection.MapUtil;
 
 public class MapUtilTest {
 
   public Map<String, String> testMap = new HashMap<>();
-  
+
   @Test
   public void putIfNotNullWhenNotNull() {
     MapUtil.putIfNotNull(testMap, "notNull", () -> "notNullValue");
@@ -30,7 +31,7 @@ public class MapUtilTest {
     MapUtil.putIfNotNull(testMap, "inDirectlyNull", () -> foo.getName());
     assertFalse(testMap.containsKey("inDirectlyNull"));
   }
-  
+
   @Test
   public void putIfNotNullWhenNullPointer() {
     Foo foo = new Foo();


### PR DESCRIPTION
Field Service needs to create a map containing no null values, and the new MapUtil class enables this as values are added. It also allows the caller to chain getters in the value lambda, and swallows NPE in that chain.

Also some minor cleanup - deprecation fixes etc