### PR TITLE
CR-645 Add Orika mapping support for UniquePropertyReferenceNumber

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/util/StringToUPRNConverter.java
+++ b/src/main/java/uk/gov/ons/ctp/common/util/StringToUPRNConverter.java
@@ -20,6 +20,7 @@ public class StringToUPRNConverter
    * @param mappingContext currently unused
    * @return UniquePropertyReferenceNumber representation of String
    */
+  @Override
   public UniquePropertyReferenceNumber convertTo(
       String source,
       Type<UniquePropertyReferenceNumber> destinationType,
@@ -35,6 +36,7 @@ public class StringToUPRNConverter
    * @param mappingContext currently unused
    * @return String representation of UniquePropertyReferenceNumber value
    */
+  @Override
   public String convertFrom(
       UniquePropertyReferenceNumber source,
       Type<String> destinationType,

--- a/src/main/java/uk/gov/ons/ctp/common/util/StringToUPRNConverter.java
+++ b/src/main/java/uk/gov/ons/ctp/common/util/StringToUPRNConverter.java
@@ -1,0 +1,44 @@
+package uk.gov.ons.ctp.common.util;
+
+import ma.glasnost.orika.MappingContext;
+import ma.glasnost.orika.converter.BidirectionalConverter;
+import ma.glasnost.orika.metadata.Type;
+import uk.gov.ons.ctp.common.model.UniquePropertyReferenceNumber;
+
+/**
+ * Orika Bi-directional custom converter to convert String to UniquePropertyReferenceNumber and vice
+ * versa.
+ */
+public class StringToUPRNConverter
+    extends BidirectionalConverter<String, UniquePropertyReferenceNumber> {
+
+  /**
+   * Converts String to UniquePropertyReferenceNumber
+   *
+   * @param source String to convert
+   * @param destinationType currently unused
+   * @param mappingContext currently unused
+   * @return UniquePropertyReferenceNumber representation of String
+   */
+  public UniquePropertyReferenceNumber convertTo(
+      String source,
+      Type<UniquePropertyReferenceNumber> destinationType,
+      MappingContext mappingContext) {
+    return new UniquePropertyReferenceNumber(source);
+  }
+
+  /**
+   * Converts UniquePropertyReferenceNumber to String
+   *
+   * @param source UniquePropertyReferenceNumber to convert
+   * @param destinationType currently unused
+   * @param mappingContext currently unused
+   * @return String representation of UniquePropertyReferenceNumber value
+   */
+  public String convertFrom(
+      UniquePropertyReferenceNumber source,
+      Type<String> destinationType,
+      MappingContext mappingContext) {
+    return String.valueOf(source.getValue());
+  }
+}


### PR DESCRIPTION
# Motivation and Context
Bi-directional custom converter added to support Orika mapping of UniquePropertyReferenceNumber found in framework. Utility to support mapping of this framework class.

<!--- Why is this change required? What problem does it solve? -->
Needed in Contact-Centre-Service as party of CR-645 changes. Already found in RH service which can be changed to use this framework class.
