### PR TITLE
CR-812 Add Accepted, Http Status 202 to RestExceptionHandler

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/error/CTPException.java
+++ b/src/main/java/uk/gov/ons/ctp/common/error/CTPException.java
@@ -37,7 +37,9 @@ public class CTPException extends Exception {
     /** For access denied */
     ACCESS_DENIED,
     /** For bad requests */
-    BAD_REQUEST;
+    BAD_REQUEST,
+    /** For operations in progress */
+    ACCEPTED_UNABLE_TO_PROCESS;
   }
 
   private Fault fault;

--- a/src/main/java/uk/gov/ons/ctp/common/error/RestExceptionHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/common/error/RestExceptionHandler.java
@@ -43,6 +43,7 @@ public class RestExceptionHandler {
     switch (status) {
       case NOT_FOUND:
       case BAD_REQUEST:
+      case ACCEPTED:
         log.with("fault", exception.getFault())
             .with("message", exception.getMessage())
             .warn("Handling CTPException", exception);
@@ -77,6 +78,9 @@ public class RestExceptionHandler {
       case SYSTEM_ERROR:
         status = HttpStatus.INTERNAL_SERVER_ERROR;
         break;
+      case ACCEPTED_UNABLE_TO_PROCESS:
+        status = HttpStatus.ACCEPTED;
+        break;
       default:
         status = HttpStatus.INTERNAL_SERVER_ERROR;
         break;
@@ -101,6 +105,9 @@ public class RestExceptionHandler {
         break;
       case INTERNAL_SERVER_ERROR:
         fault = Fault.SYSTEM_ERROR;
+        break;
+      case ACCEPTED:
+        fault = Fault.ACCEPTED_UNABLE_TO_PROCESS;
         break;
       default:
         fault = Fault.SYSTEM_ERROR;

--- a/src/test/java/uk/gov/ons/ctp/common/error/RestExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/error/RestExceptionHandlerTest.java
@@ -1,0 +1,246 @@
+package uk.gov.ons.ctp.common.error;
+
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
+
+/** Test of the Controller Advice for Spring MVC exception handling */
+public class RestExceptionHandlerTest {
+
+  @RestController
+  @RequestMapping(value = "/test")
+  private interface TestController {
+
+    @RequestMapping(value = "/run", method = RequestMethod.GET)
+    ResponseEntity<String> runTest() throws CTPException;
+  }
+
+  private MockMvc mockMvc;
+
+  @Mock private TestController testController;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(testController)
+            .setControllerAdvice(new RestExceptionHandler())
+            .build();
+  }
+
+  @Test
+  public void handleCTPException_RESOURCE_NOT_FOUND() throws Exception {
+    Mockito.doThrow(new CTPException(Fault.RESOURCE_NOT_FOUND)).when(testController).runTest();
+
+    MockHttpServletResponse response =
+        mockMvc
+            .perform(get("/test/run"))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    assertTrue(response.getContentAsString().contains(Fault.RESOURCE_NOT_FOUND.toString()));
+  }
+
+  @Test
+  public void handleCTPException_RESOURCE_VERSION_CONFLICT() throws Exception {
+    Mockito.doThrow(new CTPException(Fault.RESOURCE_VERSION_CONFLICT))
+        .when(testController)
+        .runTest();
+
+    MockHttpServletResponse response =
+        mockMvc
+            .perform(get("/test/run"))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    assertTrue(response.getContentAsString().contains(Fault.RESOURCE_VERSION_CONFLICT.toString()));
+  }
+
+  @Test
+  public void handleCTPException_ACCESS_DENIED() throws Exception {
+    Mockito.doThrow(new CTPException(Fault.ACCESS_DENIED)).when(testController).runTest();
+
+    MockHttpServletResponse response =
+        mockMvc
+            .perform(get("/test/run"))
+            .andExpect(status().isUnauthorized())
+            .andReturn()
+            .getResponse();
+    assertTrue(response.getContentAsString().contains(Fault.ACCESS_DENIED.toString()));
+  }
+
+  @Test
+  public void handleCTPException_BAD_REQUEST() throws Exception {
+    Mockito.doThrow(new CTPException(Fault.BAD_REQUEST)).when(testController).runTest();
+
+    MockHttpServletResponse response =
+        mockMvc
+            .perform(get("/test/run"))
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResponse();
+    assertTrue(response.getContentAsString().contains(Fault.BAD_REQUEST.toString()));
+  }
+
+  @Test
+  public void handleCTPException_VALIDATION_FAILED() throws Exception {
+    Mockito.doThrow(new CTPException(Fault.VALIDATION_FAILED)).when(testController).runTest();
+
+    MockHttpServletResponse response =
+        mockMvc
+            .perform(get("/test/run"))
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResponse();
+    assertTrue(response.getContentAsString().contains(Fault.VALIDATION_FAILED.toString()));
+  }
+
+  @Test
+  public void handleCTPException_SYSTEM_ERROR() throws Exception {
+    Mockito.doThrow(new CTPException(Fault.SYSTEM_ERROR)).when(testController).runTest();
+
+    MockHttpServletResponse response =
+        mockMvc
+            .perform(get("/test/run"))
+            .andExpect(status().isInternalServerError())
+            .andReturn()
+            .getResponse();
+    assertTrue(response.getContentAsString().contains(Fault.SYSTEM_ERROR.toString()));
+  }
+
+  @Test
+  public void handleCTPException_ACCEPTED_UNABLE_TO_PROCESS() throws Exception {
+    Mockito.doThrow(new CTPException(Fault.ACCEPTED_UNABLE_TO_PROCESS))
+        .when(testController)
+        .runTest();
+
+    MockHttpServletResponse response =
+        mockMvc
+            .perform(get("/test/run"))
+            .andExpect(status().isAccepted())
+            .andReturn()
+            .getResponse();
+    assertTrue(response.getContentAsString().contains(Fault.ACCEPTED_UNABLE_TO_PROCESS.toString()));
+  }
+
+  @Test
+  public void handleResponseStatusException_NOT_FOUND() throws Exception {
+    Mockito.doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND))
+        .when(testController)
+        .runTest();
+
+    MockHttpServletResponse response =
+        mockMvc
+            .perform(get("/test/run"))
+            .andExpect(status().isNotFound())
+            .andReturn()
+            .getResponse();
+    assertTrue(response.getContentAsString().contains(Fault.RESOURCE_NOT_FOUND.toString()));
+  }
+
+  @Test
+  public void handleResponseStatusException_CONFLICT() throws Exception {
+    Mockito.doThrow(new ResponseStatusException(HttpStatus.CONFLICT))
+        .when(testController)
+        .runTest();
+
+    MockHttpServletResponse response =
+        mockMvc
+            .perform(get("/test/run"))
+            .andExpect(status().isConflict())
+            .andReturn()
+            .getResponse();
+    assertTrue(response.getContentAsString().contains(Fault.RESOURCE_VERSION_CONFLICT.toString()));
+  }
+
+  @Test
+  public void handleResponseStatusException_UNAUTHORIZED() throws Exception {
+    Mockito.doThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED))
+        .when(testController)
+        .runTest();
+
+    MockHttpServletResponse response =
+        mockMvc
+            .perform(get("/test/run"))
+            .andExpect(status().isUnauthorized())
+            .andReturn()
+            .getResponse();
+    assertTrue(response.getContentAsString().contains(Fault.ACCESS_DENIED.toString()));
+  }
+
+  @Test
+  public void handleResponseStatusException_BAD_REQUEST() throws Exception {
+    Mockito.doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST))
+        .when(testController)
+        .runTest();
+
+    MockHttpServletResponse response =
+        mockMvc
+            .perform(get("/test/run"))
+            .andExpect(status().isBadRequest())
+            .andReturn()
+            .getResponse();
+    assertTrue(response.getContentAsString().contains(Fault.BAD_REQUEST.toString()));
+  }
+
+  @Test
+  public void handleResponseStatusException_INTERNAL_SERVER_ERROR() throws Exception {
+    Mockito.doThrow(new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR))
+        .when(testController)
+        .runTest();
+
+    MockHttpServletResponse response =
+        mockMvc
+            .perform(get("/test/run"))
+            .andExpect(status().isInternalServerError())
+            .andReturn()
+            .getResponse();
+    assertTrue(response.getContentAsString().contains(Fault.SYSTEM_ERROR.toString()));
+  }
+
+  @Test
+  public void handleResponseStatusException_ACCEPTED() throws Exception {
+    Mockito.doThrow(new ResponseStatusException(HttpStatus.ACCEPTED))
+        .when(testController)
+        .runTest();
+
+    MockHttpServletResponse response =
+        mockMvc
+            .perform(get("/test/run"))
+            .andExpect(status().isAccepted())
+            .andReturn()
+            .getResponse();
+    assertTrue(response.getContentAsString().contains(Fault.ACCEPTED_UNABLE_TO_PROCESS.toString()));
+  }
+
+  @Test
+  public void handleResponseStatusException_I_AM_A_TEAPOT() throws Exception {
+    Mockito.doThrow(new ResponseStatusException(HttpStatus.I_AM_A_TEAPOT))
+        .when(testController)
+        .runTest();
+
+    MockHttpServletResponse response =
+        mockMvc
+            .perform(get("/test/run"))
+            .andExpect(status().isIAmATeapot())
+            .andReturn()
+            .getResponse();
+    assertTrue(response.getContentAsString().contains(Fault.SYSTEM_ERROR.toString()));
+  }
+}


### PR DESCRIPTION
# Motivation and Context
With asynchronous messaging to Services and the need to allow for eventual state consistency within the system the Exception framework has been extended to include Http Status 202, the request has been accepted and may or may not be acted upon.

# What has changed
CTPException class extended with Fault.ACCEPTED_UNABLE_TO_PROCESS. RestExceptionHandler extended to handle this new CTPException fault code. 

# How to test?
No unit test class was present for testing the Spring MVC global exception handler class provided and which has been extended. I have provided unit tests for all previous CTPException Fault types, as well of course for the new Fault.ACCEPTED_UNABLE_TO_PROCESS.
