### PR TITLE
Cr 998 common firestore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.integration.common</groupId>
   <artifactId>framework</artifactId>
-  <version>ROBC-CR-998-SNAPSHOT</version>
+  <version>ROBC-CR-998-X-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : Integration Common Framework</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.integration.common</groupId>
   <artifactId>framework</artifactId>
-  <version>ROBC-CR-998-X-SNAPSHOT</version>
+  <version>0.0.60-SNAPSHOT-CR-998</version>
   <packaging>jar</packaging>
 
   <name>CTP : Integration Common Framework</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.integration.common</groupId>
   <artifactId>framework</artifactId>
-  <version>0.0.60-SNAPSHOT-CR-998</version>
+  <version>0.0.60-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : Integration Common Framework</name>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
 
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-aspects</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-oxm</artifactId>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.integration.common</groupId>
   <artifactId>framework</artifactId>
-  <version>0.0.60-SNAPSHOT</version>
+  <version>ROBC-CR-998-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : Integration Common Framework</name>
@@ -23,6 +23,18 @@
     <version>0.0.15</version>
   </parent>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>5.7.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -33,6 +45,11 @@
           <artifactId>spring-boot-starter-tomcat</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-firestore</artifactId>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/CloudDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/CloudDataStore.java
@@ -1,0 +1,22 @@
+package uk.gov.ons.ctp.common.cloud;
+
+import java.util.List;
+import java.util.Optional;
+import uk.gov.ons.ctp.common.error.CTPException;
+
+public interface CloudDataStore {
+
+  void connect();
+
+  void storeObject(final String schema, final String key, final Object value)
+      throws CTPException, DataStoreContentionException;
+
+  <T> Optional<T> retrieveObject(Class<T> target, final String schema, final String key)
+      throws CTPException;
+
+  public <T> List<T> search(
+      Class<T> target, final String schema, String[] fieldPath, String searchValue)
+      throws CTPException;
+
+  void deleteObject(final String schema, final String key) throws CTPException;
+}

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/CloudDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/CloudDataStore.java
@@ -5,9 +5,13 @@ import java.util.Optional;
 import java.util.Set;
 import uk.gov.ons.ctp.common.error.CTPException;
 
-public interface CloudDataStore {
-
-  void connect();
+/**
+ * Abstraction to a document data store in the cloud.
+ *
+ * <p>Clients should choose the <code>RetryableCloudDataStore</code> instead, for more robust
+ * operation.
+ */
+interface CloudDataStore {
 
   void storeObject(final String schema, final String key, final Object value)
       throws CTPException, DataStoreContentionException;

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/CloudDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/CloudDataStore.java
@@ -2,6 +2,7 @@ package uk.gov.ons.ctp.common.cloud;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import uk.gov.ons.ctp.common.error.CTPException;
 
 public interface CloudDataStore {
@@ -19,4 +20,6 @@ public interface CloudDataStore {
       throws CTPException;
 
   void deleteObject(final String schema, final String key) throws CTPException;
+
+  Set<String> getCollectionNames();
 }

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/CloudDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/CloudDataStore.java
@@ -6,12 +6,12 @@ import java.util.Set;
 import uk.gov.ons.ctp.common.error.CTPException;
 
 /**
- * Abstraction to a document data store in the cloud.
+ * Abstraction for a document data store in the cloud.
  *
- * <p>Clients should choose the <code>RetryableCloudDataStore</code> instead, for more robust
- * operation.
+ * <p>In most cases, clients of this code should choose the {@link RetryableCloudDataStore} instead,
+ * for more robust operation, especially if high volumes of traffic are expected.
  */
-interface CloudDataStore {
+public interface CloudDataStore {
 
   void storeObject(final String schema, final String key, final Object value)
       throws CTPException, DataStoreContentionException;

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/CloudDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/CloudDataStore.java
@@ -15,8 +15,7 @@ public interface CloudDataStore {
   <T> Optional<T> retrieveObject(Class<T> target, final String schema, final String key)
       throws CTPException;
 
-  public <T> List<T> search(
-      Class<T> target, final String schema, String[] fieldPath, String searchValue)
+  <T> List<T> search(Class<T> target, final String schema, String[] fieldPath, String searchValue)
       throws CTPException;
 
   void deleteObject(final String schema, final String key) throws CTPException;

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/CloudRetryListener.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/CloudRetryListener.java
@@ -1,0 +1,40 @@
+package uk.gov.ons.ctp.common.cloud;
+
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.listener.RetryListenerSupport;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CloudRetryListener extends RetryListenerSupport {
+  private static final Logger log = LoggerFactory.getLogger(CloudRetryListener.class);
+
+  @Override
+  public <T, E extends Throwable> void onError(
+      RetryContext context, RetryCallback<T, E> callback, Throwable throwable) {
+    Object operationName = context.getAttribute(RetryContext.NAME);
+    log.debug(operationName + ": Retry failed");
+  }
+
+  @Override
+  public <T, E extends Throwable> void close(
+      RetryContext context, RetryCallback<T, E> callback, Throwable throwable) {
+
+    // Spring retries have completed. Report on outcome if retries have been used.
+    if (context.getRetryCount() > 0) {
+      Object operationName = context.getAttribute(RetryContext.NAME);
+
+      if (throwable == null) {
+        int numAttempts = context.getRetryCount() + 1; // Add 1 to count the initial attempt
+        log.warn(operationName + ": Transaction successful after " + numAttempts + " attempts");
+
+      } else {
+        // On failure the retryCount actually holds the number of attempts
+        int numAttempts = context.getRetryCount();
+        log.warn(operationName + ": Transaction failed after " + numAttempts + " attempts");
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/DataStoreContentionException.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/DataStoreContentionException.java
@@ -1,0 +1,15 @@
+package uk.gov.ons.ctp.common.cloud;
+
+/**
+ * This exception is thrown when we detect that the datastore is being overloaded.
+ *
+ * <p>This will allow data store methods which have the @Retryable annotation to use retry with an
+ * exponential backoff.
+ */
+public class DataStoreContentionException extends Exception {
+  private static final long serialVersionUID = 4250385007849932900L;
+
+  public DataStoreContentionException(String message, Exception e) {
+    super(message, e);
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/DataStoreContentionException.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/DataStoreContentionException.java
@@ -3,10 +3,12 @@ package uk.gov.ons.ctp.common.cloud;
 /**
  * This exception is thrown when we detect that the datastore is being overloaded.
  *
+ * <p>It is not public, as it is part of the internal workings of the retryable data store.
+ *
  * <p>This will allow data store methods which have the @Retryable annotation to use retry with an
  * exponential backoff.
  */
-public class DataStoreContentionException extends Exception {
+class DataStoreContentionException extends Exception {
   private static final long serialVersionUID = 4250385007849932900L;
 
   public DataStoreContentionException(String message, Exception e) {

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
@@ -39,25 +39,6 @@ public class FirestoreDataStore implements CloudDataStore {
     firestore = FirestoreOptions.getDefaultInstance().getService();
   }
 
-  // FIXME
-  private static long count = 0;
-  private static long count2 = 1;
-
-  private void testing() throws DataStoreContentionException {
-    String schema = "ROBC";
-
-    if (count++ % 50 == 0 || count2 % 3 == 0) {
-      count2++;
-      // log.with("schema", schema + count).with("key", key + count2).info("Firestore contention
-      // detected");
-      log.info("Firestore contention detected count: {} count2: {}", count, count2);
-      throw new DataStoreContentionException(
-          "Firestore contention on schema '" + schema + "'", new Exception());
-    }
-  }
-
-  // FIXME
-
   /**
    * Write object to Firestore collection. If the collection already holds an object with the
    * specified key then the contents of the value will be overwritten.
@@ -75,8 +56,6 @@ public class FirestoreDataStore implements CloudDataStore {
   public void storeObject(final String schema, final String key, final Object value)
       throws CTPException, DataStoreContentionException {
     log.with(schema).with(key).debug("Saving object to Firestore");
-
-    // testing(); // FIXME
 
     // Store the object
     ApiFuture<WriteResult> result = firestore.collection(schema).document(key).set(value);

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
@@ -38,6 +38,25 @@ public class FirestoreDataStore implements CloudDataStore {
     firestore = FirestoreOptions.getDefaultInstance().getService();
   }
 
+  // FIXME
+  private static long count = 0;
+  private static long count2 = 1;
+
+  private void testing() throws DataStoreContentionException {
+    String schema = "ROBC";
+
+    if (count++ % 50 == 0 || count2 % 3 == 0) {
+      count2++;
+      // log.with("schema", schema + count).with("key", key + count2).info("Firestore contention
+      // detected");
+      log.info("Firestore contention detected count: {} count2: {}", count, count2);
+      throw new DataStoreContentionException(
+          "Firestore contention on schema '" + schema + "'", new Exception());
+    }
+  }
+
+  // FIXME
+
   /**
    * Write object to Firestore collection. If the collection already holds an object with the
    * specified key then the contents of the value will be overwritten.
@@ -55,6 +74,8 @@ public class FirestoreDataStore implements CloudDataStore {
   public void storeObject(final String schema, final String key, final Object value)
       throws CTPException, DataStoreContentionException {
     log.with(schema).with(key).debug("Saving object to Firestore");
+
+    // testing(); // FIXME
 
     // Store the object
     ApiFuture<WriteResult> result = firestore.collection(schema).document(key).set(value);

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.error.CTPException.Fault;
@@ -26,15 +27,13 @@ import uk.gov.ons.ctp.common.error.CTPException.Fault;
 public class FirestoreDataStore implements CloudDataStore {
   private static final Logger log = LoggerFactory.getLogger(FirestoreDataStore.class);
 
-  // Names of environment variables which firestore uses for connection information
-  public static final String FIRESTORE_PROJECT_ENV_NAME = "GOOGLE_CLOUD_PROJECT";
+  @Value("${GOOGLE_CLOUD_PROJECT}")
+  private String gcpProject;
 
   private Firestore firestore;
 
   public void connect() {
-    String googleProjectName = System.getenv(FirestoreDataStore.FIRESTORE_PROJECT_ENV_NAME);
-    log.with(googleProjectName).debug("Connecting to Firestore project");
-
+    log.info("Connecting to Firestore project {}", gcpProject);
     firestore = FirestoreOptions.getDefaultInstance().getService();
   }
 

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.common.error.CTPException;
@@ -32,7 +33,8 @@ public class FirestoreDataStore implements CloudDataStore {
 
   private Firestore firestore;
 
-  public void connect() {
+  @PostConstruct
+  public void create() {
     log.info("Connecting to Firestore project {}", gcpProject);
     firestore = FirestoreOptions.getDefaultInstance().getService();
   }
@@ -154,6 +156,8 @@ public class FirestoreDataStore implements CloudDataStore {
   /**
    * Read an object from Firestore.
    *
+   * @param <T> The object type that results should be returned in.
+   * @param target the class of the object type that results should be returned in.
    * @param schema - is the name of the collection which holds the object.
    * @param key - identifies the object within the collection.
    * @return - Optional containing the object if it was found, otherwise the optional will contain
@@ -199,12 +203,13 @@ public class FirestoreDataStore implements CloudDataStore {
   /**
    * Runs a firestore object search. This returns objects whose field is equal to the search value.
    *
-   * @param target is the object type that results should be returned in.
+   * @param <T> The object type that results should be returned in.
+   * @param target the class of the object type that results should be returned in.
    * @param schema is the schema to search.
    * @param fieldPathElements is an array of strings that describe the path to the search field. eg,
    *     [ "case", "addresss", "postcode" ]
    * @param searchValue is the value that the field must equal for it to be returned as a result.
-   * @return An optional which contains a List of results.
+   * @return the List of results.
    * @throws CTPException if anything goes wrong.
    */
   public <T> List<T> search(

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
@@ -13,8 +13,10 @@ import com.google.cloud.firestore.WriteResult;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.common.error.CTPException;
@@ -261,5 +263,17 @@ public class FirestoreDataStore implements CloudDataStore {
           "Failed to delete object from Firestore. Schema: " + schema + " with key " + key;
       throw new CTPException(Fault.SYSTEM_ERROR, e, failureMessage);
     }
+  }
+
+  /**
+   * Returns the names of top level Firestore collections.
+   *
+   * @return a Set with the names of the current Firestore collections.
+   */
+  @Override
+  public Set<String> getCollectionNames() {
+    Set<String> collectionNames = new HashSet<>();
+    firestore.listCollections().forEach(c -> collectionNames.add(c.getId()));
+    return collectionNames;
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
@@ -1,0 +1,265 @@
+package uk.gov.ons.ctp.common.cloud;
+
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.FieldPath;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.cloud.firestore.QuerySnapshot;
+import com.google.cloud.firestore.WriteResult;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
+
+@Service
+public class FirestoreDataStore implements CloudDataStore {
+  private static final Logger log = LoggerFactory.getLogger(FirestoreDataStore.class);
+
+  // Names of environment variables which firestore uses for connection information
+  public static final String FIRESTORE_PROJECT_ENV_NAME = "GOOGLE_CLOUD_PROJECT";
+
+  private Firestore firestore;
+
+  public void connect() {
+    String googleProjectName = System.getenv(FirestoreDataStore.FIRESTORE_PROJECT_ENV_NAME);
+    log.with(googleProjectName).debug("Connecting to Firestore project");
+
+    firestore = FirestoreOptions.getDefaultInstance().getService();
+  }
+
+  /**
+   * Write object to Firestore collection. If the collection already holds an object with the
+   * specified key then the contents of the value will be overwritten.
+   *
+   * @param schema - holds the name of the collection that the object will be added to.
+   * @param key - identifies the object within the collection.
+   * @param value - is the object to be written to Firestore. To be storable/retrievable by
+   *     Firestore it must either have public fields or provide get/set methods that allow access to
+   *     its contents.
+   * @throws CTPException if any failure was detected interacting with Firestore.
+   * @throws DataStoreContentionException if the object was not stored but should be retried with an
+   *     exponential backoff.
+   */
+  @Override
+  public void storeObject(final String schema, final String key, final Object value)
+      throws CTPException, DataStoreContentionException {
+    log.with(schema).with(key).debug("Saving object to Firestore");
+
+    // Store the object
+    ApiFuture<WriteResult> result = firestore.collection(schema).document(key).set(value);
+
+    // Wait for Firestore to complete
+    try {
+      result.get();
+      log.with(schema).with(key).debug("Firestore save completed");
+
+    } catch (Exception e) {
+      log.with("schema", schema)
+          .with("key", key)
+          .with("Exception chain", describeExceptionChain(e))
+          .error(e, "Failed to create object in Firestore");
+
+      if (isRetryableFirestoreException(e)) {
+        // Firestore is overloaded. Use Spring exponential backoff to force a retry.
+        // This is intended to catch 'Too much contention' exceptions and any other
+        // Firestore exception where it is worth retrying.
+        log.with("schema", schema).with("key", key).info("Firestore contention detected");
+        throw new DataStoreContentionException(
+            "Firestore contention on schema '" + schema + "'", e);
+      }
+
+      String failureMessage =
+          "Failed to create object in Firestore. Schema: " + schema + " with key " + key;
+      throw new CTPException(Fault.SYSTEM_ERROR, e, failureMessage);
+    }
+  }
+
+  // This method supports logging which aims to protect against future unexpected changes in
+  // how google throw exceptions for retryable operations. If Google change Firestore behaviour
+  // and we don't detect a retryable operation then we want our logging to be good enough to
+  // allow a code fix.
+  private String describeExceptionChain(Throwable e) {
+    StringBuilder builder = new StringBuilder();
+
+    while (e != null) {
+      builder.append("caused by " + e.getClass().getName() + " ");
+      e = e.getCause();
+    }
+
+    return builder.toString().trim();
+  }
+
+  private boolean isRetryableFirestoreException(Exception e) {
+    boolean retryable = false;
+
+    // Traverse the exception chain looking for a StatusRuntimeException
+    Throwable t = e;
+    while (t != null) {
+      if (t instanceof StatusRuntimeException) {
+        StatusRuntimeException statusRuntimeException = (StatusRuntimeException) t;
+        Code failureCode = statusRuntimeException.getStatus().getCode();
+
+        if (failureCode == Status.ABORTED.getCode()
+            || failureCode == Status.DEADLINE_EXCEEDED.getCode()
+            || failureCode == Status.UNAVAILABLE.getCode()) {
+          retryable = true;
+          break;
+        } else {
+          log.with("Status", statusRuntimeException.getStatus())
+              .with("Status code", failureCode)
+              .with("Status description", statusRuntimeException.getStatus().getDescription())
+              .info(
+                  "StatusRuntimeException found in exception heirarchy"
+                      + ", but it's not a retryable code");
+        }
+      }
+
+      t = t.getCause();
+    }
+
+    return retryable;
+  }
+
+  /**
+   * Read an object from Firestore.
+   *
+   * @param schema - is the name of the collection which holds the object.
+   * @param key - identifies the object within the collection.
+   * @return - Optional containing the object if it was found, otherwise the optional will contain
+   *     null.
+   */
+  @Override
+  public <T> Optional<T> retrieveObject(Class<T> target, final String schema, final String key)
+      throws CTPException {
+
+    log.with("schema", schema).with("key", key).debug("Fetching object from Firestore");
+
+    // Submit read request to firestore
+    FieldPath fieldPathForId = FieldPath.documentId();
+    List<T> documents = runSearch(target, schema, fieldPathForId, key);
+
+    // Squash results down to single document
+    Optional<T> result = null;
+    if (documents.isEmpty()) {
+      result = Optional.empty();
+      log.debug("Search didn't find any objects");
+    } else if (documents.size() == 1) {
+      result = Optional.of(documents.get(0));
+      log.debug("Search found single result");
+    } else {
+      log.with("results.size", documents.size())
+          .with("schema", schema)
+          .with("key", key)
+          .error("Firestore found more than one result object");
+      String failureMessage =
+          "Firestore returned more than 1 result object. Returned "
+              + documents.size()
+              + " objects for Schema '"
+              + schema
+              + "' with key '"
+              + key
+              + "'";
+      throw new CTPException(Fault.SYSTEM_ERROR, failureMessage);
+    }
+
+    return result;
+  }
+
+  /**
+   * Runs a firestore object search. This returns objects whose field is equal to the search value.
+   *
+   * @param target is the object type that results should be returned in.
+   * @param schema is the schema to search.
+   * @param fieldPathElements is an array of strings that describe the path to the search field. eg,
+   *     [ "case", "addresss", "postcode" ]
+   * @param searchValue is the value that the field must equal for it to be returned as a result.
+   * @return An optional which contains a List of results.
+   * @throws CTPException if anything goes wrong.
+   */
+  public <T> List<T> search(
+      Class<T> target, final String schema, String[] fieldPathElements, String searchValue)
+      throws CTPException {
+    log.with(schema)
+        .with(fieldPathElements)
+        .with(searchValue)
+        .with(target)
+        .debug("Searching Firestore");
+
+    // Run a query for a custom search path
+    FieldPath fieldPath = FieldPath.of(fieldPathElements);
+    List<T> r = runSearch(target, schema, fieldPath, searchValue);
+    log.with("resultSize", r.size()).debug("Firestore search returning results");
+
+    return r;
+  }
+
+  private <T> List<T> runSearch(
+      Class<T> target, final String schema, FieldPath fieldPath, String searchValue)
+      throws CTPException {
+    // Run a query
+    ApiFuture<QuerySnapshot> query =
+        firestore.collection(schema).whereEqualTo(fieldPath, searchValue).get();
+
+    // Wait for query to complete and get results
+    QuerySnapshot querySnapshot;
+    try {
+      querySnapshot = query.get();
+    } catch (Exception e) {
+      log.with("schema", schema).with("fieldPath", fieldPath).error(e, "Failed to search schema");
+      String failureMessage =
+          "Failed to search schema '" + schema + "' by field '" + "'" + fieldPath;
+      throw new CTPException(Fault.SYSTEM_ERROR, e, failureMessage);
+    }
+    List<QueryDocumentSnapshot> documents = querySnapshot.getDocuments();
+
+    // Convert the results to Java objects
+    List<T> results;
+    try {
+      results = documents.stream().map(d -> d.toObject(target)).collect(Collectors.toList());
+    } catch (Exception e) {
+      log.with("target", target).error(e, "Failed to convert Firestore result to Java object");
+      String failureMessage =
+          "Failed to convert Firestore result to Java object. Target class '" + target + "'";
+      throw new CTPException(Fault.SYSTEM_ERROR, e, failureMessage);
+    }
+
+    return results;
+  }
+
+  /**
+   * Delete an object from Firestore. No error is thrown if the object doesn't exist.
+   *
+   * @param schema - is the name of the collection which holds the object.
+   * @param key - identifies the object within the collection.
+   */
+  @Override
+  public void deleteObject(final String schema, final String key) throws CTPException {
+    log.with("schema", schema).with("key", key).debug("Deleting object from Firestore");
+
+    // Tell firestore to delete object
+    DocumentReference docRef = firestore.collection(schema).document(key);
+    ApiFuture<WriteResult> result = docRef.delete();
+
+    // Wait for delete to complete
+    try {
+      result.get();
+      log.debug("Firestore delete completed");
+    } catch (Exception e) {
+      log.with("schema", schema)
+          .with("key", key)
+          .error(e, "Failed to delete object from Firestore");
+      String failureMessage =
+          "Failed to delete object from Firestore. Schema: " + schema + " with key " + key;
+      throw new CTPException(Fault.SYSTEM_ERROR, e, failureMessage);
+    }
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/RetryConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/RetryConfig.java
@@ -1,0 +1,15 @@
+package uk.gov.ons.ctp.common.cloud;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties("cloud-storage.backoff")
+@Data
+public class RetryConfig {
+  private int initial;
+  private String multiplier; // String type to handle floats without rounding
+  private int max;
+  private int maxAttempts;
+}

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStore.java
@@ -1,0 +1,86 @@
+package uk.gov.ons.ctp.common.cloud;
+
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
+
+/**
+ * Decorator for <code>CloudDataStore</code>. It is responsible for handling exponential backoffs
+ * when the datastore is becoming overloaded.
+ */
+@Service
+public class RetryableCloudDataStore {
+  private static final Logger log = LoggerFactory.getLogger(RetryableCloudDataStore.class);
+
+  @Value("${GOOGLE_CLOUD_PROJECT}")
+  String gcpProject;
+
+  private CloudDataStore cloudDataStore;
+
+  @Autowired
+  public RetryableCloudDataStore(CloudDataStore cloudDataStore) {
+    this.cloudDataStore = cloudDataStore;
+    this.cloudDataStore.connect();
+  }
+
+  public void storeObject(
+      final String schema, final String key, final Object value, final String id)
+      throws CTPException {
+    try {
+      this.storeObject(schema, key, value);
+    } catch (DataStoreContentionException e) {
+      String identity = value.getClass().getName() + ": " + id;
+      log.error("Retries exhausted for storage of {}", identity);
+      throw new CTPException(Fault.SYSTEM_ERROR, e, "Retries exhausted for storage of " + identity);
+    }
+  }
+
+  @Retryable(
+      label = "storeObject",
+      include = DataStoreContentionException.class,
+      backoff =
+          @Backoff(
+              delayExpression = "#{${cloudStorage.backoffInitial}}",
+              multiplierExpression = "#{${cloudStorage.backoffMultiplier}}",
+              maxDelayExpression = "#{${cloudStorage.backoffMax}}"),
+      maxAttemptsExpression = "#{${cloudStorage.backoffMaxAttempts}}",
+      listeners = "cloudRetryListener")
+  public void storeObject(final String schema, final String key, final Object value)
+      throws CTPException, DataStoreContentionException {
+    cloudDataStore.storeObject(schema, key, value);
+  }
+
+  public <T> Optional<T> retrieveObject(Class<T> target, final String schema, final String key)
+      throws CTPException {
+    return cloudDataStore.retrieveObject(target, schema, key);
+  }
+
+  public <T> List<T> search(
+      Class<T> target, final String schema, String[] fieldPath, String searchValue)
+      throws CTPException {
+    return cloudDataStore.search(target, schema, fieldPath, searchValue);
+  }
+
+  /**
+   * When attempts to retry object storage have been exhausted this method is invoked and it can
+   * then throw the exception (triggering Rabbit retries). If this is not done then the message
+   * won't be eligible for another attempt or writing to the dead letter queue.
+   *
+   * @param e is the final exception in the storeObject retries.
+   * @throws Exception the exception which caused the final attempt to fail.
+   */
+  @Recover
+  public void doRecover(Exception e) throws Exception {
+    log.with(e.getMessage()).debug("Datastore recovery throwing exception");
+    throw e;
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStore.java
@@ -3,11 +3,33 @@ package uk.gov.ons.ctp.common.cloud;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.EnableRetry;
 import uk.gov.ons.ctp.common.error.CTPException;
 
 /**
- * Abstraction to a document data store in the cloud, with robust retry capability during store
+ * Abstraction for a document data store in the cloud, with robust retry capability during store
  * operation.
+ *
+ * <p>In order to use this class the client must apply the configuration annotation {@link
+ * EnableRetry}.
+ *
+ * <p>Here is an example of the application properties that must be configured to control retry
+ * characteristics (in a YAML style as you might place in Spring Boot <code>application.yaml</code>:
+ *
+ * <pre>
+ * cloud-storage:
+ *   backoff:
+ *     initial: 100
+ *     multiplier: 1.2
+ *     max: 16000
+ *     max-attempts: 30
+ * </pre>
+ *
+ * <p>The example above, will retry a maximum of 30 times, or a maximum delay of 16 seconds. The
+ * initial retry delay is 100 mSec. Each subsequent retry will be 1.2 times as long as the previous.
+ *
+ * <p>See {@link Backoff} annotation for more information on the backoff parameters.
  */
 public interface RetryableCloudDataStore {
 

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStore.java
@@ -1,87 +1,65 @@
 package uk.gov.ons.ctp.common.cloud;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Recover;
-import org.springframework.retry.annotation.Retryable;
-import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.common.error.CTPException;
-import uk.gov.ons.ctp.common.error.CTPException.Fault;
 
 /**
- * Decorator for <code>CloudDataStore</code>. It is responsible for handling exponential backoffs
- * when the datastore is becoming overloaded.
+ * Abstraction to a document data store in the cloud, with robust retry capability during store
+ * operation.
  */
-@Service
-public class RetryableCloudDataStore {
-  private static final Logger log = LoggerFactory.getLogger(RetryableCloudDataStore.class);
-
-  private CloudDataStore cloudDataStore;
-
-  @Autowired
-  public RetryableCloudDataStore(CloudDataStore cloudDataStore) {
-    this.cloudDataStore = cloudDataStore;
-    this.cloudDataStore.connect();
-  }
-
-  public void storeObject(
-      final String schema, final String key, final Object value, final String id)
-      throws CTPException {
-    try {
-      this.storeObject(schema, key, value);
-    } catch (DataStoreContentionException e) {
-      String identity = value.getClass().getName() + ": " + id;
-      log.error("Retries exhausted for storage of {}", identity);
-      throw new CTPException(Fault.SYSTEM_ERROR, e, "Retries exhausted for storage of " + identity);
-    }
-  }
-
-  @Retryable(
-      label = "storeObject",
-      include = DataStoreContentionException.class,
-      backoff =
-          @Backoff(
-              delayExpression = "#{${cloudStorage.backoffInitial}}",
-              multiplierExpression = "#{${cloudStorage.backoffMultiplier}}",
-              maxDelayExpression = "#{${cloudStorage.backoffMax}}"),
-      maxAttemptsExpression = "#{${cloudStorage.backoffMaxAttempts}}",
-      listeners = "cloudRetryListener")
-  public void storeObject(final String schema, final String key, final Object value)
-      throws CTPException, DataStoreContentionException {
-    cloudDataStore.storeObject(schema, key, value);
-  }
-
-  public <T> Optional<T> retrieveObject(Class<T> target, final String schema, final String key)
-      throws CTPException {
-    return cloudDataStore.retrieveObject(target, schema, key);
-  }
-
-  public <T> List<T> search(
-      Class<T> target, final String schema, String[] fieldPath, String searchValue)
-      throws CTPException {
-    return cloudDataStore.search(target, schema, fieldPath, searchValue);
-  }
-
-  public Set<String> getCollectionNames() {
-    return cloudDataStore.getCollectionNames();
-  }
+public interface RetryableCloudDataStore {
 
   /**
-   * When attempts to retry object storage have been exhausted this method is invoked and it can
-   * then throw the exception (triggering Rabbit retries). If this is not done then the message
-   * won't be eligible for another attempt or writing to the dead letter queue.
+   * Write object to cloud collection. If the collection already holds an object with the specified
+   * key then the contents of the value will be overwritten.
    *
-   * @param e is the final exception in the storeObject retries.
-   * @throws Exception the exception which caused the final attempt to fail.
+   * <p>The implementation will employ a retry strategy if contention errors are detected.
+   *
+   * @param schema the name of the collection that the object will be added to.
+   * @param key key for the object within the collection.
+   * @param value the object to be written to the collection.
+   * @param id a readable identifier for the object for error reporting. This may or may not be
+   *     different from the <code>key</code> parameter; for instance if key were a hash then a
+   *     different identifier may be better for the logged error/exception.
+   * @throws CTPException an error has occurred, that could not be rectified by the retry strategy.
    */
-  @Recover
-  public void doRecover(Exception e) throws Exception {
-    log.with(e.getMessage()).debug("Datastore recovery throwing exception");
-    throw e;
-  }
+  void storeObject(final String schema, final String key, final Object value, final String id)
+      throws CTPException;
+
+  /**
+   * Read an object.
+   *
+   * @param <T> The object type that results should be returned in.
+   * @param target the class of the object type that results should be returned in.
+   * @param schema the name of the collection which holds the object.
+   * @param key identifies the object within the collection.
+   * @return Optional containing the object if it was found.
+   */
+  <T> Optional<T> retrieveObject(Class<T> target, final String schema, final String key)
+      throws CTPException;
+
+  /**
+   * Runs an object search. This returns objects whose field is equal to the search value.
+   *
+   * @param <T> The object type that results should be returned in.
+   * @param target the class of the object type that results should be returned in.
+   * @param schema is the schema to search.
+   * @param fieldPathElements is an array of strings that describe the path to the search field. eg,
+   *     [ "case", "addresss", "postcode" ]
+   * @param searchValue is the value that the field must equal for it to be returned as a result.
+   * @return the list of results.
+   * @throws CTPException on error
+   */
+  <T> List<T> search(
+      Class<T> target, final String schema, String[] fieldPathElements, String searchValue)
+      throws CTPException;
+
+  /**
+   * Get the names of top level cloud collections.
+   *
+   * @return a Set with the names of the current collections.
+   */
+  Set<String> getCollectionNames();
 }

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStore.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
@@ -21,9 +20,6 @@ import uk.gov.ons.ctp.common.error.CTPException.Fault;
 @Service
 public class RetryableCloudDataStore {
   private static final Logger log = LoggerFactory.getLogger(RetryableCloudDataStore.class);
-
-  @Value("${GOOGLE_CLOUD_PROJECT}")
-  String gcpProject;
 
   private CloudDataStore cloudDataStore;
 

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStore.java
@@ -4,6 +4,7 @@ import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.retry.annotation.Backoff;
@@ -68,6 +69,10 @@ public class RetryableCloudDataStore {
       Class<T> target, final String schema, String[] fieldPath, String searchValue)
       throws CTPException {
     return cloudDataStore.search(target, schema, fieldPath, searchValue);
+  }
+
+  public Set<String> getCollectionNames() {
+    return cloudDataStore.getCollectionNames();
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStore.java
@@ -36,6 +36,7 @@ public interface RetryableCloudDataStore {
    * @param schema the name of the collection which holds the object.
    * @param key identifies the object within the collection.
    * @return Optional containing the object if it was found.
+   * @throws CTPException on error
    */
   <T> Optional<T> retrieveObject(Class<T> target, final String schema, final String key)
       throws CTPException;

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreImpl.java
@@ -1,0 +1,90 @@
+package uk.gov.ons.ctp.common.cloud;
+
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
+
+/**
+ * Decorator for <code>CloudDataStore</code>. It is responsible for handling exponential backoffs
+ * when the datastore is becoming overloaded.
+ */
+@Service
+public class RetryableCloudDataStoreImpl implements RetryableCloudDataStore {
+  private static final Logger log = LoggerFactory.getLogger(RetryableCloudDataStoreImpl.class);
+
+  private CloudDataStore cloudDataStore;
+
+  @Autowired
+  public RetryableCloudDataStoreImpl(CloudDataStore cloudDataStore) {
+    this.cloudDataStore = cloudDataStore;
+  }
+
+  @Override
+  public void storeObject(
+      final String schema, final String key, final Object value, final String id)
+      throws CTPException {
+    try {
+      this.storeWithRetry(schema, key, value);
+    } catch (DataStoreContentionException e) {
+      String identity = value.getClass().getName() + ": " + id;
+      log.error("Retries exhausted for storage of {}", identity);
+      throw new CTPException(Fault.SYSTEM_ERROR, e, "Retries exhausted for storage of " + identity);
+    }
+  }
+
+  @Retryable(
+      label = "storeObject",
+      include = DataStoreContentionException.class,
+      backoff =
+          @Backoff(
+              delayExpression = "#{${cloudStorage.backoffInitial}}",
+              multiplierExpression = "#{${cloudStorage.backoffMultiplier}}",
+              maxDelayExpression = "#{${cloudStorage.backoffMax}}"),
+      maxAttemptsExpression = "#{${cloudStorage.backoffMaxAttempts}}",
+      listeners = "cloudRetryListener")
+  public void storeWithRetry(final String schema, final String key, final Object value)
+      throws CTPException, DataStoreContentionException {
+    cloudDataStore.storeObject(schema, key, value);
+  }
+
+  @Override
+  public <T> Optional<T> retrieveObject(Class<T> target, final String schema, final String key)
+      throws CTPException {
+    return cloudDataStore.retrieveObject(target, schema, key);
+  }
+
+  @Override
+  public <T> List<T> search(
+      Class<T> target, final String schema, String[] fieldPathElements, String searchValue)
+      throws CTPException {
+    return cloudDataStore.search(target, schema, fieldPathElements, searchValue);
+  }
+
+  @Override
+  public Set<String> getCollectionNames() {
+    return cloudDataStore.getCollectionNames();
+  }
+
+  /**
+   * When attempts to retry object storage have been exhausted this method is invoked and it can
+   * then throw the exception (triggering Rabbit retries). If this is not done then the message
+   * won't be eligible for another attempt or writing to the dead letter queue.
+   *
+   * @param e is the final exception in the storeObject retries.
+   * @throws Exception the exception which caused the final attempt to fail.
+   */
+  @Recover
+  public void doRecover(Exception e) throws Exception {
+    log.with(e.getMessage()).debug("Datastore recovery throwing exception");
+    throw e;
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreImpl.java
@@ -46,10 +46,10 @@ public class RetryableCloudDataStoreImpl implements RetryableCloudDataStore {
       include = DataStoreContentionException.class,
       backoff =
           @Backoff(
-              delayExpression = "#{${cloudStorage.backoffInitial}}",
-              multiplierExpression = "#{${cloudStorage.backoffMultiplier}}",
-              maxDelayExpression = "#{${cloudStorage.backoffMax}}"),
-      maxAttemptsExpression = "#{${cloudStorage.backoffMaxAttempts}}",
+              delayExpression = "#{${cloud-storage.backoff.initial}}",
+              multiplierExpression = "#{${cloud-storage.backoff.multiplier}}",
+              maxDelayExpression = "#{${cloud-storage.backoff.max}}"),
+      maxAttemptsExpression = "#{${cloud-storage.backoff.max-attempts}}",
       listeners = "cloudRetryListener")
   public void storeWithRetry(final String schema, final String key, final Object value)
       throws CTPException, DataStoreContentionException {

--- a/src/main/java/uk/gov/ons/ctp/common/config/YmlConfigReader.java
+++ b/src/main/java/uk/gov/ons/ctp/common/config/YmlConfigReader.java
@@ -58,6 +58,7 @@ public class YmlConfigReader {
   /**
    * This method uses Jackson to convert the current state of the property data into a Java object.
    *
+   * @param <T> The result object type.
    * @param clazz is the class to convert the data into.
    * @return Object containing the configuration date.
    * @throws CTPException if the conversion failed.

--- a/src/test/java/uk/gov/ons/ctp/common/cloud/CloudTestBase.java
+++ b/src/test/java/uk/gov/ons/ctp/common/cloud/CloudTestBase.java
@@ -1,0 +1,27 @@
+package uk.gov.ons.ctp.common.cloud;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public abstract class CloudTestBase {
+  static final DummyCase CASE1 = new DummyCase("1", new DummyContact("jo", "Smith"));
+  static final DummyCase CASE2 = new DummyCase("2", new DummyContact("Iain", "Smith"));
+  static final String TEST_SCHEMA = "TEST_SCHEMA";
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  static class DummyCase {
+    private String id;
+    private DummyContact contact;
+  }
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  static class DummyContact {
+    private String forename;
+    private String surname;
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStoreTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStoreTest.java
@@ -1,0 +1,418 @@
+package uk.gov.ons.ctp.common.cloud;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.FieldPath;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.Query;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.cloud.firestore.QuerySnapshot;
+import com.google.cloud.firestore.WriteResult;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.ons.ctp.common.error.CTPException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FirestoreDataStoreTest {
+  private static final DummyCase CASE1 = new DummyCase("1", new DummyContact("jo"));
+  private static final DummyCase CASE2 = new DummyCase("2", new DummyContact("Iain"));
+  private static final String TEST_SCHEMA = "IT_TEST_SCHEMA";
+
+  private static FirestoreDataStore firestoreDataStore = new FirestoreDataStore();
+
+  @Mock private Firestore firestore;
+
+  @Before
+  public void setUp() {
+    ReflectionTestUtils.setField(firestoreDataStore, "firestore", firestore);
+  }
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  static class DummyCase {
+    private String id;
+    private DummyContact contact;
+  }
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  static class DummyContact {
+    private String forename;
+  }
+
+  @Test
+  public void testStoreObject() throws Exception {
+    ApiFuture<WriteResult> apiFuture =
+        mockFirestoreForExpectedStore(TEST_SCHEMA, CASE1.getId(), CASE1, null);
+
+    firestoreDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1);
+    verify(apiFuture).get();
+  }
+
+  @Test
+  public void testStoreObject_fails() throws Exception {
+    ExecutionException firestoreException =
+        new ExecutionException("fake Firestore exception", null);
+    mockFirestoreForExpectedStore(TEST_SCHEMA, CASE1.getId(), CASE1, firestoreException);
+
+    boolean exceptionCaught = false;
+    try {
+      firestoreDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1);
+    } catch (CTPException e) {
+      assertTrue(e.getMessage(), e.getMessage().contains("Failed to create object"));
+      assertTrue(
+          e.getCause().getMessage(),
+          e.getCause().getMessage().contains("fake Firestore exception"));
+      exceptionCaught = true;
+    }
+    assertTrue(exceptionCaught);
+  }
+
+  @Test
+  public void testStoreObject_detectsContention() throws Exception {
+    // Build chain of exceptions as per Firestore
+    Exception rootCauseException = new StatusRuntimeException(Status.ABORTED);
+    Exception causeException = new RuntimeException("e2", rootCauseException);
+    Exception firestoreException =
+        new java.util.concurrent.ExecutionException("e3", causeException);
+
+    mockFirestoreForExpectedStore(TEST_SCHEMA, CASE1.getId(), CASE1, firestoreException);
+
+    boolean exceptionCaught = false;
+    try {
+      firestoreDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1);
+    } catch (DataStoreContentionException e) {
+      assertTrue(e.getMessage(), e.getMessage().contains("contention on schema 'IT_TEST_SCHEMA'"));
+      exceptionCaught = true;
+    }
+    assertTrue("Failed to detect datastore contention", exceptionCaught);
+  }
+
+  @Test
+  public void testStoreObject_doesNotIncorrectlyDetectContention() throws Exception {
+    // Build chain of exceptions, but not with same values as Firestore uses for contention
+    Exception rootCauseException = new StatusRuntimeException(Status.ALREADY_EXISTS);
+    Exception causeException = new RuntimeException("e2", rootCauseException);
+    Exception firestoreException =
+        new java.util.concurrent.ExecutionException("e3", causeException);
+
+    mockFirestoreForExpectedStore(TEST_SCHEMA, CASE1.getId(), CASE1, firestoreException);
+
+    boolean contentionDetected = false;
+    boolean ctpExceptionCreated = false;
+    try {
+      firestoreDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1);
+    } catch (DataStoreContentionException e) {
+      contentionDetected = true;
+    } catch (CTPException e) {
+      ctpExceptionCreated = true;
+    }
+    assertFalse("Incorrectly diagnoised datastore contention", contentionDetected);
+    assertTrue(ctpExceptionCreated);
+  }
+
+  @Test
+  public void testRetrieveObject_found() throws Exception {
+    mockFirestoreRetrieveObject(TEST_SCHEMA, CASE1.getId(), null, CASE1);
+
+    // Verify that retrieveObject returns the expected result
+    Optional<DummyCase> retrievedCase1 =
+        firestoreDataStore.retrieveObject(DummyCase.class, TEST_SCHEMA, CASE1.getId());
+    assertTrue(retrievedCase1.isPresent());
+    assertEquals(CASE1, retrievedCase1.get());
+  }
+
+  @Test
+  public void testRetrieveObject_notFound() throws Exception {
+    String unknownId = UUID.randomUUID().toString();
+
+    mockFirestoreRetrieveObject(TEST_SCHEMA, unknownId, null);
+
+    // Submit a read for unknown object
+    Optional<DummyCase> retrievedCase1 =
+        firestoreDataStore.retrieveObject(DummyCase.class, TEST_SCHEMA, unknownId);
+
+    // Verify that reading a non existent object returns an empty result set
+    assertTrue(retrievedCase1.isEmpty());
+  }
+
+  @Test
+  public void testRetrieveObject_failsWithMultipleResultsFound() throws Exception {
+    // Force failure by making the retrieve return more than 1 result object
+    mockFirestoreRetrieveObject(TEST_SCHEMA, CASE1.getId(), null, CASE1, CASE1);
+
+    // Verify that retrieveObject fails because of more than 1 result
+    boolean exceptionCaught = false;
+    try {
+      firestoreDataStore.retrieveObject(DummyCase.class, TEST_SCHEMA, CASE1.getId());
+    } catch (CTPException e) {
+      assertTrue(e.getMessage(), e.getMessage().contains("Firestore returned more than 1"));
+      exceptionCaught = true;
+    }
+    assertTrue(exceptionCaught);
+  }
+
+  @Test
+  public void testSearch_noResults() throws Exception {
+    mockFirestoreSearch(TEST_SCHEMA, "Bob", null, null);
+
+    // Verify that there are no results when searching for unknown forename
+    String[] searchCriteria = new String[] {"contact", "forename"};
+    List<DummyCase> retrievedCase1 =
+        firestoreDataStore.search(DummyCase.class, TEST_SCHEMA, searchCriteria, "Bob");
+    assertTrue(retrievedCase1.isEmpty());
+  }
+
+  @Test
+  public void testSearch_singleResult() throws Exception {
+    mockFirestoreSearch(TEST_SCHEMA, CASE1.getContact().getForename(), null, null, CASE1);
+
+    // Verify that search can find the  first case
+    String[] searchCriteria = new String[] {"contact", "forename"};
+    List<DummyCase> retrievedCase1 =
+        firestoreDataStore.search(
+            DummyCase.class, TEST_SCHEMA, searchCriteria, CASE1.getContact().getForename());
+    assertEquals(1, retrievedCase1.size());
+    assertEquals(CASE1.getId(), retrievedCase1.get(0).getId());
+    assertEquals(CASE1, retrievedCase1.get(0));
+  }
+
+  @Test
+  public void testSearch_multipleResults() throws Exception {
+    mockFirestoreSearch(TEST_SCHEMA, "Smith", null, null, CASE1, CASE2);
+
+    // Verify that search can find the  first case
+    String[] searchCriteria = new String[] {"contact", "surname"};
+    List<DummyCase> retrievedCase1 =
+        firestoreDataStore.search(DummyCase.class, TEST_SCHEMA, searchCriteria, "Smith");
+    assertEquals(2, retrievedCase1.size());
+    assertEquals(CASE1.getId(), retrievedCase1.get(0).getId());
+    assertEquals(CASE1, retrievedCase1.get(0));
+    assertEquals(CASE2.getId(), retrievedCase1.get(1).getId());
+    assertEquals(CASE2, retrievedCase1.get(1));
+  }
+
+  @Test
+  public void testSearch_failsWithFirestoreException() throws Exception {
+    ExecutionException firestoreException =
+        new ExecutionException("fake Firestore exception", null);
+    mockFirestoreSearch(TEST_SCHEMA, "Smith", firestoreException, null, CASE1, CASE2);
+
+    boolean exceptionCaught = false;
+    try {
+      String[] searchCriteria = new String[] {"contact", "surname"};
+      firestoreDataStore.search(DummyCase.class, TEST_SCHEMA, searchCriteria, "Smith");
+    } catch (CTPException e) {
+      assertTrue(e.getMessage(), e.getMessage().contains("Failed to search"));
+      assertTrue(
+          e.getCause().getMessage(),
+          e.getCause().getMessage().contains("fake Firestore exception"));
+      exceptionCaught = true;
+    }
+    assertTrue(exceptionCaught);
+  }
+
+  @Test
+  public void testSearch_failsSerialisationException() throws Exception {
+    RuntimeException serialisationException = new RuntimeException("Could not deserialize object");
+    mockFirestoreSearch(TEST_SCHEMA, "Smith", null, serialisationException, CASE1, CASE2);
+
+    boolean exceptionCaught = false;
+    try {
+      String[] searchCriteria = new String[] {"contact", "surname"};
+      firestoreDataStore.search(DummyCase.class, TEST_SCHEMA, searchCriteria, "Smith");
+    } catch (CTPException e) {
+      assertTrue(e.getMessage(), e.getMessage().contains("Failed to convert"));
+      assertTrue(
+          e.getCause().getMessage(),
+          e.getCause().getMessage().contains("Could not deserialize object"));
+      exceptionCaught = true;
+    }
+    assertTrue(exceptionCaught);
+  }
+
+  @Test
+  public void testDelete_success() throws Exception {
+    ApiFuture<WriteResult> apiFuture =
+        mockFirestoreForExpectedDelete(TEST_SCHEMA, CASE1.getId(), null);
+
+    // Delete it
+    firestoreDataStore.deleteObject(TEST_SCHEMA, CASE1.getId());
+    verify(apiFuture).get();
+  }
+
+  @Test
+  public void testDelete_failsWithFirestoreException() throws Exception {
+    ExecutionException firestoreException =
+        new ExecutionException("fake Firestore exception", null);
+    mockFirestoreForExpectedDelete(TEST_SCHEMA, CASE1.getId(), firestoreException);
+
+    // Attempt a deletion
+    boolean exceptionCaught = false;
+    try {
+      firestoreDataStore.deleteObject(TEST_SCHEMA, CASE1.getId());
+    } catch (CTPException e) {
+      assertTrue(e.getMessage(), e.getMessage().contains("Failed to delete"));
+      assertTrue(
+          e.getCause().getMessage(),
+          e.getCause().getMessage().contains("fake Firestore exception"));
+      exceptionCaught = true;
+    }
+    assertTrue(exceptionCaught);
+  }
+
+  @Test
+  public void testDelete_onNonExistentObject() throws Exception {
+    UUID nonExistantUUID = UUID.randomUUID();
+
+    ApiFuture<WriteResult> apiFuture =
+        mockFirestoreForAttemptedDelete(TEST_SCHEMA, nonExistantUUID.toString());
+
+    // Attempt to delete a non existent object
+    firestoreDataStore.deleteObject(TEST_SCHEMA, nonExistantUUID.toString());
+    verify(apiFuture).get();
+  }
+
+  private ApiFuture<WriteResult> mockFirestoreForExpectedStore(
+      String expectedSchema, String expectedKey, Object expectedValue, Exception exception)
+      throws InterruptedException, ExecutionException {
+    ApiFuture<WriteResult> apiFuture = genericMock(ApiFuture.class);
+    if (exception == null) {
+      when(apiFuture.get()).thenReturn(null);
+    } else {
+      when(apiFuture.get()).thenThrow(exception);
+    }
+
+    DocumentReference documentReference = Mockito.mock(DocumentReference.class);
+    when(documentReference.set(eq(expectedValue))).thenReturn(apiFuture);
+
+    CollectionReference collectionReference = Mockito.mock(CollectionReference.class);
+    when(collectionReference.document(eq(expectedKey))).thenReturn(documentReference);
+
+    when(firestore.collection(eq(expectedSchema))).thenReturn(collectionReference);
+
+    return apiFuture;
+  }
+
+  private void mockFirestoreRetrieveObject(
+      String expectedSchema, String expectedSearchValue, Exception exception, DummyCase... case1)
+      throws InterruptedException, ExecutionException {
+    mockFirestoreSearch(expectedSchema, expectedSearchValue, exception, null, case1);
+  }
+
+  private void mockFirestoreSearch(
+      String expectedSchema,
+      String expectedSearchValue,
+      Exception searchException,
+      Exception serialisationException,
+      DummyCase... resultData)
+      throws InterruptedException, ExecutionException {
+
+    ApiFuture<QuerySnapshot> apiFuture = genericMock(ApiFuture.class);
+
+    if (searchException == null && serialisationException == null) {
+      // Build list of results which are to be returned
+      List<QueryDocumentSnapshot> results = new ArrayList<>();
+      for (DummyCase caseObj : resultData) {
+        QueryDocumentSnapshot doc1 = Mockito.mock(QueryDocumentSnapshot.class);
+        when(doc1.toObject(eq(DummyCase.class))).thenReturn(caseObj);
+        results.add(doc1);
+      }
+
+      QuerySnapshot querySnapshot = Mockito.mock(QuerySnapshot.class);
+      when(querySnapshot.getDocuments()).thenReturn(results);
+
+      when(apiFuture.get()).thenReturn(querySnapshot);
+    } else if (searchException != null) {
+      when(apiFuture.get()).thenThrow(searchException);
+    } else {
+      // SerialisationException
+      List<QueryDocumentSnapshot> results = new ArrayList<>();
+      QueryDocumentSnapshot doc1 = Mockito.mock(QueryDocumentSnapshot.class);
+      when(doc1.toObject(eq(DummyCase.class))).thenThrow(serialisationException);
+      results.add(doc1);
+
+      QuerySnapshot querySnapshot = Mockito.mock(QuerySnapshot.class);
+      when(querySnapshot.getDocuments()).thenReturn(results);
+
+      when(apiFuture.get()).thenReturn(querySnapshot);
+    }
+
+    Query query = Mockito.mock(Query.class);
+    when(query.get()).thenReturn(apiFuture);
+
+    CollectionReference collectionReference = Mockito.mock(CollectionReference.class);
+    when(collectionReference.whereEqualTo((FieldPath) any(), eq(expectedSearchValue)))
+        .thenReturn(query);
+
+    when(firestore.collection(eq(expectedSchema))).thenReturn(collectionReference);
+  }
+
+  private ApiFuture<WriteResult> mockFirestoreForExpectedDelete(
+      String expectedSchema, String expectedKey, Exception exception)
+      throws InterruptedException, ExecutionException {
+    ApiFuture<WriteResult> apiFuture = genericMock(ApiFuture.class);
+    if (exception == null) {
+      when(apiFuture.get()).thenReturn(null);
+    } else {
+      when(apiFuture.get()).thenThrow(exception);
+    }
+
+    DocumentReference documentReference = Mockito.mock(DocumentReference.class);
+    when(documentReference.delete()).thenReturn(apiFuture);
+
+    CollectionReference collectionReference = Mockito.mock(CollectionReference.class);
+    when(collectionReference.document(eq(expectedKey))).thenReturn(documentReference);
+
+    when(firestore.collection(eq(expectedSchema))).thenReturn(collectionReference);
+
+    return apiFuture;
+  }
+
+  private ApiFuture<WriteResult> mockFirestoreForAttemptedDelete(
+      String expectedSchema, String expectedKey) throws InterruptedException, ExecutionException {
+    ApiFuture<WriteResult> apiFuture = genericMock(ApiFuture.class);
+    when(apiFuture.get()).thenReturn(null);
+
+    DocumentReference documentReference = Mockito.mock(DocumentReference.class);
+    when(documentReference.delete()).thenReturn(apiFuture);
+
+    CollectionReference collectionReference = Mockito.mock(CollectionReference.class);
+    when(collectionReference.document(eq(expectedKey))).thenReturn(documentReference);
+
+    when(firestore.collection(eq(expectedSchema))).thenReturn(collectionReference);
+
+    return apiFuture;
+  }
+
+  @SuppressWarnings("unchecked")
+  static <T> T genericMock(Class<? super T> classToMock) {
+    return (T) Mockito.mock(classToMock);
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStoreTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStoreTest.java
@@ -20,8 +20,10 @@ import com.google.cloud.firestore.WriteResult;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import lombok.AllArgsConstructor;
@@ -298,6 +300,27 @@ public class FirestoreDataStoreTest {
     firestoreDataStore.deleteObject(TEST_SCHEMA, nonExistantUUID.toString());
     verify(apiFuture).get();
   }
+
+  @Test
+  public void testGetCollectionNames() {
+    // Build names of collections that mock Firestore will list
+    CollectionReference collectionA = Mockito.mock(CollectionReference.class);
+    when(collectionA.getId()).thenReturn("collectionA");
+    CollectionReference collectionB = Mockito.mock(CollectionReference.class);
+    when(collectionB.getId()).thenReturn("collectionB");
+
+    // Create results from listCollections
+    Iterable<CollectionReference> collections = Arrays.asList(collectionA, collectionB);
+    when(firestore.listCollections()).thenReturn(collections);
+
+    Set<String> collectionNames = firestoreDataStore.getCollectionNames();
+
+    assertTrue(collectionNames.toString(), collectionNames.contains("collectionA"));
+    assertTrue(collectionNames.toString(), collectionNames.contains("collectionB"));
+    assertEquals(2, collectionNames.size());
+  }
+
+  // --- helpers ...
 
   private ApiFuture<WriteResult> mockFirestoreForExpectedStore(
       String expectedSchema, String expectedKey, Object expectedValue, Exception exception)

--- a/src/test/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStoreTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStoreTest.java
@@ -26,9 +26,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,10 +36,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.ons.ctp.common.error.CTPException;
 
 @RunWith(MockitoJUnitRunner.class)
-public class FirestoreDataStoreTest {
-  private static final DummyCase CASE1 = new DummyCase("1", new DummyContact("jo"));
-  private static final DummyCase CASE2 = new DummyCase("2", new DummyContact("Iain"));
-  private static final String TEST_SCHEMA = "IT_TEST_SCHEMA";
+public class FirestoreDataStoreTest extends CloudTestBase {
 
   private static FirestoreDataStore firestoreDataStore = new FirestoreDataStore();
 
@@ -51,21 +45,6 @@ public class FirestoreDataStoreTest {
   @Before
   public void setUp() {
     ReflectionTestUtils.setField(firestoreDataStore, "firestore", firestore);
-  }
-
-  @Data
-  @NoArgsConstructor
-  @AllArgsConstructor
-  static class DummyCase {
-    private String id;
-    private DummyContact contact;
-  }
-
-  @Data
-  @NoArgsConstructor
-  @AllArgsConstructor
-  static class DummyContact {
-    private String forename;
   }
 
   @Test
@@ -110,7 +89,7 @@ public class FirestoreDataStoreTest {
     try {
       firestoreDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1);
     } catch (DataStoreContentionException e) {
-      assertTrue(e.getMessage(), e.getMessage().contains("contention on schema 'IT_TEST_SCHEMA'"));
+      assertTrue(e.getMessage(), e.getMessage().contains("contention on schema 'TEST_SCHEMA'"));
       exceptionCaught = true;
     }
     assertTrue("Failed to detect datastore contention", exceptionCaught);

--- a/src/test/java/uk/gov/ons/ctp/common/cloud/Firestore_IT.java
+++ b/src/test/java/uk/gov/ons/ctp/common/cloud/Firestore_IT.java
@@ -1,0 +1,211 @@
+package uk.gov.ons.ctp.common.cloud;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * This class tests the FirestoreDataStore class by connecting to a real firestore project.
+ *
+ * <p>To run this code: This class tests Firestore using the firestore API. 1) Uncomment the @Ignore
+ * annotations. 2) Make sure the Firestore environment variables are set. eg, I use:
+ * GOOGLE_APPLICATION_CREDENTIALS =
+ * /Users/peterbochel/.config/gcloud/application_default_credentials.json GOOGLE_CLOUD_PROJECT =
+ * census-rh-peterb
+ */
+@Ignore
+public class Firestore_IT {
+
+  private static final String FIRESTORE_CREDENTIALS_ENV_NAME = "GOOGLE_APPLICATION_CREDENTIALS";
+  private static final String FIRESTORE_PROJECT_ENV_NAME = "GOOGLE_CLOUD_PROJECT";
+  private static final String TEST_SCHEMA = "IT_TEST_SCHEMA";
+
+  private static final DummyCase CASE1 = new DummyCase("1", new DummyContact("jo", "Smith"));
+  private static final DummyCase CASE2 = new DummyCase("2", new DummyContact("Iain", "Smith"));
+
+  private static FirestoreDataStore firestoreDataStore;
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  static class DummyCase {
+    private String id;
+    private DummyContact contact;
+  }
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  static class DummyContact {
+    private String forename;
+    private String surname;
+  }
+
+  @BeforeClass
+  public static void setUp() {
+    firestoreDataStore = new FirestoreDataStore();
+    firestoreDataStore.connect();
+
+    String googleCredentials = System.getenv(FIRESTORE_CREDENTIALS_ENV_NAME);
+    String googleProjectName = System.getenv(FIRESTORE_PROJECT_ENV_NAME);
+    System.out.printf(
+        "Connecting to Firestore project '%s' using credentials at '%s'\n",
+        googleProjectName, googleCredentials);
+    Firestore firestore = FirestoreOptions.getDefaultInstance().getService();
+
+    ReflectionTestUtils.setField(firestoreDataStore, "firestore", firestore);
+  }
+
+  @Before
+  public void clearTestData() throws Exception {
+    // Add data to collection
+    firestoreDataStore.deleteObject(TEST_SCHEMA, CASE1.getId());
+    firestoreDataStore.deleteObject(TEST_SCHEMA, CASE2.getId());
+  }
+
+  @Test
+  public void testStoreAndRetrieve() throws Exception {
+    // Add data to collection
+    firestoreDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1);
+    firestoreDataStore.storeObject(TEST_SCHEMA, CASE2.getId(), CASE2);
+
+    verifyStoredCase(CASE1);
+    verifyStoredCase(CASE2);
+  }
+
+  private void verifyStoredCase(DummyCase caze) throws Exception {
+    Optional<DummyCase> retrievedCase =
+        firestoreDataStore.retrieveObject(DummyCase.class, TEST_SCHEMA, caze.getId());
+    assertTrue(retrievedCase.isPresent());
+    DummyCase rcase = retrievedCase.get();
+    assertEquals(caze, rcase);
+  }
+
+  @Test
+  public void testReplaceObject() throws Exception {
+    // Add data to collection
+    String id = CASE1.getId();
+    firestoreDataStore.storeObject(TEST_SCHEMA, id, CASE1);
+
+    // Verify that 1st case can be read back
+    Optional<DummyCase> retrievedCase =
+        firestoreDataStore.retrieveObject(DummyCase.class, TEST_SCHEMA, id);
+    assertEquals(CASE1, retrievedCase.get());
+
+    // Replace contents with CASE2
+    firestoreDataStore.storeObject(TEST_SCHEMA, id, CASE2);
+
+    // Confirm contents of 'id', which was CASE1, is now CASE2
+    retrievedCase = firestoreDataStore.retrieveObject(DummyCase.class, TEST_SCHEMA, id);
+    assertEquals(CASE2, retrievedCase.get());
+  }
+
+  @Test
+  public void testRetrieveObject_unknownObject() throws Exception {
+    firestoreDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1);
+
+    // Verify that reading a non existent object returns null
+    String unknownUUID = UUID.randomUUID().toString();
+    Optional<DummyCase> retrievedCase =
+        firestoreDataStore.retrieveObject(DummyCase.class, TEST_SCHEMA, unknownUUID);
+    assertTrue(retrievedCase.isEmpty());
+  }
+
+  @Test
+  public void testSearch_multipleResults() throws Exception {
+    // Add data to collection
+    firestoreDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1);
+    firestoreDataStore.storeObject(TEST_SCHEMA, CASE2.getId(), CASE2);
+
+    // Verify that search can find the first case
+    String[] searchByForename = new String[] {"contact", "forename"};
+    List<DummyCase> retrievedCase1 =
+        firestoreDataStore.search(
+            DummyCase.class, TEST_SCHEMA, searchByForename, CASE1.getContact().getForename());
+    assertEquals(1, retrievedCase1.size());
+    assertEquals(CASE1.getId(), retrievedCase1.get(0).getId());
+    assertEquals(CASE1, retrievedCase1.get(0));
+
+    // Verify that search can find the second case
+    String[] searchBySurname = new String[] {"contact", "surname"};
+    List<DummyCase> retrievedCase2 =
+        firestoreDataStore.search(
+            DummyCase.class, TEST_SCHEMA, searchBySurname, CASE2.getContact().getSurname());
+    assertEquals(2, retrievedCase2.size());
+    assertEquals(CASE1, retrievedCase2.get(0));
+    assertEquals(CASE2, retrievedCase2.get(1));
+  }
+
+  @Test
+  public void testSearch_noResults() throws Exception {
+    firestoreDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1);
+
+    // Verify that there are no results when searching for unknown forename
+    String[] searchCriteria = new String[] {"contact", "forename"};
+    List<DummyCase> retrievedCase1 =
+        firestoreDataStore.search(DummyCase.class, TEST_SCHEMA, searchCriteria, "Bob");
+    assertTrue(retrievedCase1.isEmpty());
+  }
+
+  @Test
+  public void testSearch_serialisationFailure() throws Exception {
+    firestoreDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1);
+
+    // Verify that search can find the first case
+    boolean exceptionCaught = false;
+    try {
+      String[] searchByForename = new String[] {"contact", "forename"};
+      firestoreDataStore.search(
+          String.class, TEST_SCHEMA, searchByForename, CASE1.getContact().getForename());
+    } catch (Exception e) {
+      assertTrue(e.getCause().getMessage(), e.getCause().getMessage().contains("e"));
+      exceptionCaught = true;
+    }
+    assertTrue(exceptionCaught);
+  }
+
+  @Test
+  public void testDelete_success() throws Exception {
+    firestoreDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1);
+
+    // Verify that the case can be read back
+    Optional<DummyCase> retrievedCase =
+        firestoreDataStore.retrieveObject(DummyCase.class, TEST_SCHEMA, CASE1.getId());
+    assertEquals(CASE1, retrievedCase.get());
+
+    // Delete it
+    firestoreDataStore.deleteObject(TEST_SCHEMA, CASE1.getId());
+
+    // Now confirm that we can no longer read the deleted case
+    retrievedCase = firestoreDataStore.retrieveObject(DummyCase.class, TEST_SCHEMA, CASE1.getId());
+    assertTrue(retrievedCase.isEmpty());
+  }
+
+  @Test
+  public void testDelete_onNonExistantObject() throws Exception {
+    // Load test data, just so that Firestore has some data loaded
+    firestoreDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1);
+
+    // Attempt to delete a non existent object. Should not fail
+    UUID nonExistantUUID = UUID.randomUUID();
+    firestoreDataStore.deleteObject(TEST_SCHEMA, nonExistantUUID.toString());
+
+    // Confirm that firestore can't read the case
+    Optional<DummyCase> retrievedCase =
+        firestoreDataStore.retrieveObject(DummyCase.class, TEST_SCHEMA, nonExistantUUID.toString());
+    assertTrue(retrievedCase.isEmpty());
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/common/cloud/Firestore_IT.java
+++ b/src/test/java/uk/gov/ons/ctp/common/cloud/Firestore_IT.java
@@ -3,8 +3,6 @@ package uk.gov.ons.ctp.common.cloud;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.google.cloud.firestore.Firestore;
-import com.google.cloud.firestore.FirestoreOptions;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -28,8 +26,6 @@ import org.springframework.test.util.ReflectionTestUtils;
  */
 @Ignore
 public class Firestore_IT {
-
-  private static final String FIRESTORE_CREDENTIALS_ENV_NAME = "GOOGLE_APPLICATION_CREDENTIALS";
   private static final String FIRESTORE_PROJECT_ENV_NAME = "GOOGLE_CLOUD_PROJECT";
   private static final String TEST_SCHEMA = "IT_TEST_SCHEMA";
 
@@ -57,16 +53,9 @@ public class Firestore_IT {
   @BeforeClass
   public static void setUp() {
     firestoreDataStore = new FirestoreDataStore();
-    firestoreDataStore.connect();
-
-    String googleCredentials = System.getenv(FIRESTORE_CREDENTIALS_ENV_NAME);
-    String googleProjectName = System.getenv(FIRESTORE_PROJECT_ENV_NAME);
-    System.out.printf(
-        "Connecting to Firestore project '%s' using credentials at '%s'\n",
-        googleProjectName, googleCredentials);
-    Firestore firestore = FirestoreOptions.getDefaultInstance().getService();
-
-    ReflectionTestUtils.setField(firestoreDataStore, "firestore", firestore);
+    ReflectionTestUtils.setField(
+        firestoreDataStore, "gcpProject", System.getenv(FIRESTORE_PROJECT_ENV_NAME));
+    firestoreDataStore.create();
   }
 
   @Before

--- a/src/test/java/uk/gov/ons/ctp/common/cloud/Firestore_IT.java
+++ b/src/test/java/uk/gov/ons/ctp/common/cloud/Firestore_IT.java
@@ -6,9 +6,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -25,30 +22,9 @@ import org.springframework.test.util.ReflectionTestUtils;
  * census-rh-peterb
  */
 @Ignore
-public class Firestore_IT {
+public class Firestore_IT extends CloudTestBase {
   private static final String FIRESTORE_PROJECT_ENV_NAME = "GOOGLE_CLOUD_PROJECT";
-  private static final String TEST_SCHEMA = "IT_TEST_SCHEMA";
-
-  private static final DummyCase CASE1 = new DummyCase("1", new DummyContact("jo", "Smith"));
-  private static final DummyCase CASE2 = new DummyCase("2", new DummyContact("Iain", "Smith"));
-
   private static FirestoreDataStore firestoreDataStore;
-
-  @Data
-  @NoArgsConstructor
-  @AllArgsConstructor
-  static class DummyCase {
-    private String id;
-    private DummyContact contact;
-  }
-
-  @Data
-  @NoArgsConstructor
-  @AllArgsConstructor
-  static class DummyContact {
-    private String forename;
-    private String surname;
-  }
 
   @BeforeClass
   public static void setUp() {

--- a/src/test/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreSpringTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreSpringTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.test.context.ContextConfiguration;
@@ -20,8 +21,10 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.error.CTPException.Fault;
 
 @EnableRetry
+@EnableConfigurationProperties
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = {RetryableCloudDataStoreImpl.class, CloudRetryListener.class})
+@ContextConfiguration(
+    classes = {RetryableCloudDataStoreImpl.class, CloudRetryListener.class, RetryConfig.class})
 @TestPropertySource(
     properties = {
       "cloud-storage.backoff.initial=10",

--- a/src/test/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreSpringTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreSpringTest.java
@@ -1,0 +1,86 @@
+package uk.gov.ons.ctp.common.cloud;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
+
+@EnableRetry
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {RetryableCloudDataStoreImpl.class, CloudRetryListener.class})
+@TestPropertySource(
+    properties = {
+      "cloud-storage.backoff.initial=10",
+      "cloud-storage.backoff.multiplier=1.2",
+      "cloud-storage.backoff.max=300",
+      "cloud-storage.backoff.max-attempts=3",
+    })
+public class RetryableCloudDataStoreSpringTest extends CloudTestBase {
+
+  @MockBean private CloudDataStore cloudDataStore;
+
+  @Autowired private RetryableCloudDataStore retryDataStore;
+
+  @Test
+  public void shouldAutowire() {
+    assertNotNull(retryDataStore);
+  }
+
+  @Test
+  public void shouldStore() throws Exception {
+    retryDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1, "a case");
+    verify(cloudDataStore).storeObject(eq(TEST_SCHEMA), eq(CASE1.getId()), eq(CASE1));
+  }
+
+  @Test
+  public void shouldRetryStoreOnce() throws Exception {
+    doThrow(new DataStoreContentionException("argh", new Exception()))
+        .doNothing()
+        .when(cloudDataStore)
+        .storeObject(TEST_SCHEMA, CASE1.getId(), CASE1);
+
+    retryDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1, "a case");
+    verify(cloudDataStore, times(2)).storeObject(eq(TEST_SCHEMA), eq(CASE1.getId()), eq(CASE1));
+  }
+
+  @Test
+  public void shouldRetryStoreTwice() throws Exception {
+    doThrow(new DataStoreContentionException("argh", new Exception()))
+        .doThrow(new DataStoreContentionException("argh", new Exception()))
+        .doNothing()
+        .when(cloudDataStore)
+        .storeObject(TEST_SCHEMA, CASE1.getId(), CASE1);
+
+    retryDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1, "a case");
+    verify(cloudDataStore, times(3)).storeObject(eq(TEST_SCHEMA), eq(CASE1.getId()), eq(CASE1));
+  }
+
+  @Test
+  public void shouldRetryWithTillExhaustion() throws Exception {
+    doThrow(new DataStoreContentionException("argh", new Exception()))
+        .when(cloudDataStore)
+        .storeObject(TEST_SCHEMA, CASE1.getId(), CASE1);
+    try {
+      retryDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1, "a case");
+      fail();
+    } catch (CTPException e) {
+      assertEquals(Fault.SYSTEM_ERROR, e.getFault());
+      assertEquals("Retries exhausted for storage of DummyCase: a case", e.getMessage());
+    }
+    verify(cloudDataStore, times(3)).storeObject(eq(TEST_SCHEMA), eq(CASE1.getId()), eq(CASE1));
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreTest.java
@@ -1,0 +1,105 @@
+package uk.gov.ons.ctp.common.cloud;
+
+import static java.util.stream.Collectors.toSet;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RetryableCloudDataStoreTest extends CloudTestBase {
+
+  @Mock private CloudDataStore cloudDataStore;
+
+  private RetryableCloudDataStoreImpl.LocalStore internalStore;
+
+  @InjectMocks private RetryableCloudDataStoreImpl retryDataStoreImpl;
+
+  private RetryableCloudDataStore retryDataStore;
+
+  @Before
+  public void setup() {
+    internalStore = new RetryableCloudDataStoreImpl.LocalStore(cloudDataStore);
+    ReflectionTestUtils.setField(retryDataStoreImpl, "localStore", internalStore);
+    retryDataStore = retryDataStoreImpl;
+  }
+
+  @Test
+  public void shouldListCollectionNames() {
+    Set<String> names = Arrays.asList("Fred", "Julie", "Tyrone").stream().collect(toSet());
+    when(cloudDataStore.getCollectionNames()).thenReturn(names);
+    assertEquals(names, retryDataStore.getCollectionNames());
+  }
+
+  @Test(expected = CTPException.class)
+  public void shouldRethrowOnRecover() throws Exception {
+    retryDataStoreImpl.doRecover(new CTPException(Fault.SYSTEM_ERROR));
+  }
+
+  @Test
+  public void shouldSearch() throws Exception {
+    List<DummyCase> mockResults = Arrays.asList(CASE1, CASE2).stream().collect(Collectors.toList());
+    String[] searchCriteria = new String[] {"contact", "surname"};
+    when(cloudDataStore.search(DummyCase.class, TEST_SCHEMA, searchCriteria, "Smith"))
+        .thenReturn(mockResults);
+    List<DummyCase> results =
+        retryDataStore.search(DummyCase.class, TEST_SCHEMA, searchCriteria, "Smith");
+    assertEquals(mockResults, results);
+  }
+
+  @Test
+  public void shouldRetrieveCase() throws Exception {
+    when(cloudDataStore.retrieveObject(DummyCase.class, TEST_SCHEMA, CASE1.getId()))
+        .thenReturn(Optional.of(CASE1));
+    Optional<DummyCase> retrievedCase =
+        retryDataStore.retrieveObject(DummyCase.class, TEST_SCHEMA, CASE1.getId());
+    assertEquals(CASE1, retrievedCase.get());
+  }
+
+  @Test
+  public void shouldRetrieveNothing() throws Exception {
+    when(cloudDataStore.retrieveObject(DummyCase.class, TEST_SCHEMA, CASE1.getId()))
+        .thenReturn(Optional.empty());
+    Optional<DummyCase> retrievedCase =
+        retryDataStore.retrieveObject(DummyCase.class, TEST_SCHEMA, CASE1.getId());
+    assertTrue(retrievedCase.isEmpty());
+  }
+
+  @Test
+  public void shouldStore() throws Exception {
+    retryDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1, "a case");
+    verify(cloudDataStore).storeObject(eq(TEST_SCHEMA), eq(CASE1.getId()), eq(CASE1));
+  }
+
+  @Test
+  public void shouldThrowCtpExceptionWhenRetriesExhausted() throws Exception {
+    doThrow(new DataStoreContentionException("argh", new Exception()))
+        .when(cloudDataStore)
+        .storeObject(TEST_SCHEMA, CASE1.getId(), CASE1);
+    try {
+      retryDataStore.storeObject(TEST_SCHEMA, CASE1.getId(), CASE1, "a case");
+      fail();
+    } catch (CTPException e) {
+      assertEquals(Fault.SYSTEM_ERROR, e.getFault());
+      assertEquals("Retries exhausted for storage of DummyCase: a case", e.getMessage());
+    }
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/cloud/RetryableCloudDataStoreTest.java
@@ -29,16 +29,17 @@ public class RetryableCloudDataStoreTest extends CloudTestBase {
 
   @Mock private CloudDataStore cloudDataStore;
 
-  private RetryableCloudDataStoreImpl.LocalStore internalStore;
+  private RetryableCloudDataStoreImpl.Retrier retrier;
 
   @InjectMocks private RetryableCloudDataStoreImpl retryDataStoreImpl;
 
   private RetryableCloudDataStore retryDataStore;
+  private RetryConfig retryConfig = new RetryConfig();
 
   @Before
   public void setup() {
-    internalStore = new RetryableCloudDataStoreImpl.LocalStore(cloudDataStore);
-    ReflectionTestUtils.setField(retryDataStoreImpl, "localStore", internalStore);
+    retrier = new RetryableCloudDataStoreImpl.Retrier(cloudDataStore, retryConfig);
+    ReflectionTestUtils.setField(retryDataStoreImpl, "retrier", retrier);
     retryDataStore = retryDataStoreImpl;
   }
 

--- a/src/test/java/uk/gov/ons/ctp/common/error/CTPExceptionTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/error/CTPExceptionTest.java
@@ -35,10 +35,8 @@ public class CTPExceptionTest {
    */
   @Test
   public void testFaultOnly() throws Exception {
-
     CTPException ctpe = new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND);
     String result = write(ctpe);
-    System.out.println(result);
 
     assertEquals("RESOURCE_NOT_FOUND", (String) JsonPath.read(result, "$.error.code"));
     assertEquals("Non Specific Error", (String) JsonPath.read(result, "$.error.message"));
@@ -56,7 +54,6 @@ public class CTPExceptionTest {
     NullPointerException npe = new NullPointerException("Testing is great");
     CTPException ctpe = new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND, npe);
     String result = write(ctpe);
-    System.out.println(result);
 
     assertEquals("RESOURCE_NOT_FOUND", (String) JsonPath.read(result, "$.error.code"));
     assertEquals("Testing is great", (String) JsonPath.read(result, "$.error.message"));
@@ -75,7 +72,6 @@ public class CTPExceptionTest {
     CTPException ctpe =
         new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND, "Testing %d %d %s", 1, 2, "three");
     String result = write(ctpe);
-    System.out.println(result);
 
     assertEquals("RESOURCE_NOT_FOUND", (String) JsonPath.read(result, "$.error.code"));
     assertEquals("Testing 1 2 three", (String) JsonPath.read(result, "$.error.message"));
@@ -96,7 +92,6 @@ public class CTPExceptionTest {
         new CTPException(
             CTPException.Fault.RESOURCE_NOT_FOUND, npe, "Testing %d %d %s", 1, 2, "three");
     String result = write(ctpe);
-    System.out.println(result);
 
     assertEquals("RESOURCE_NOT_FOUND", (String) JsonPath.read(result, "$.error.code"));
     assertEquals("Testing 1 2 three", (String) JsonPath.read(result, "$.error.message"));

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<!-- quiet tests -->
+<configuration/>


### PR DESCRIPTION
# Motivation and Context
This merges 2 sets of firestore interface and retry code into one place in the common framework.
CR-998 points out that this code will be needed in a 3rd place for future work also.

# What has changed
- The firestore code that was written in RHSvc has been copied over to the framework and then modified to fit generic cases for both RHSvc and CCSvc
- additions needed for CCSvc have been added, in particular the **getCollectionNames** method.
- The retry logic has been embedded in the framework
- The configuration parameters have been made "more YAML"
- The configuration parameters are logged , and read using standard Spring configuration properties.
- New unit tests have been written
- Additional javadoc written at the main interface to help ensure understanding.

# What has NOT changed
- The tunings parameters for retry backoff are in the application.yml of RHSvc and CCSvc which are in other projects. These will not be changed as part of this activity

# How to test?
- Unit tests should test the main functionality
- Manual tests (adding temporary exception throws from the code) shows the functionality is working and that the exponential backoff is correct.
- The sampleGenerator / EventGenerator was used to generate many 1000's of events for testing
- Showing the contention problem with a real firestore is tricky and given that Google seem to have increased their limits since the original CR-555 ticket, then we may only be able to reproduce this within the performance environment.

# Links
- CR-555
- https://cloud.google.com/storage/docs/request-rate

