### PR TITLE
CR-1047 Extend UPRN validation to allow 13 digits.

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/domain/UniquePropertyReferenceNumber.java
+++ b/src/main/java/uk/gov/ons/ctp/common/domain/UniquePropertyReferenceNumber.java
@@ -11,9 +11,9 @@ import org.apache.commons.lang3.StringUtils;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UniquePropertyReferenceNumber {
-  public static final String UPRN_RE = "^\\d{1,12}$";
+  public static final String UPRN_RE = "^\\d{1,13}$";
   public static final long UPRN_MIN = 0L;
-  public static final long UPRN_MAX = 999999999999L;
+  public static final long UPRN_MAX = 9999999999999L;
 
   @JsonCreator
   public static UniquePropertyReferenceNumber create(String uprn) {

--- a/src/test/java/uk/gov/ons/ctp/common/domain/UniquePropertyReferenceNumberTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/domain/UniquePropertyReferenceNumberTest.java
@@ -8,11 +8,17 @@ import lombok.SneakyThrows;
 import org.junit.Test;
 
 public class UniquePropertyReferenceNumberTest {
-  private static final String UPRN_STR = "3341111111111";
+  private static final String UPRN_MAX = "9999999999999";
+  private static final String UPRN_MIN = "0";
+  private static final String UPRN_MIN_FAIL = "-1";
+  private static final String UPRN_MAX_FAIL = "99999999999991";
+  private static final String UPRN_CONVERSION_FAIL = "x";
+  private static final long UPRN_DEFAULT_VALUE = 0L;
+
   private static final UniquePropertyReferenceNumber A_UPRN =
-      new UniquePropertyReferenceNumber(UPRN_STR);
+      new UniquePropertyReferenceNumber(UPRN_MAX);
   private static final UniquePropertyReferenceNumber ANOTHER_UPRN =
-      new UniquePropertyReferenceNumber("1347459999");
+      new UniquePropertyReferenceNumber(UPRN_MIN);
 
   @Data
   static class Dto {
@@ -23,9 +29,9 @@ public class UniquePropertyReferenceNumberTest {
   @Test
   public void shouldDeserialiseSingleValue() {
     final UniquePropertyReferenceNumber uprn =
-        deserialise(UPRN_STR, UniquePropertyReferenceNumber.class);
+        deserialise(UPRN_MAX, UniquePropertyReferenceNumber.class);
     assertEquals(
-        "resulting UPRN should match expected value: " + UPRN_STR,
+        "resulting UPRN should match expected value: " + UPRN_MAX,
         (Long) A_UPRN.getValue(),
         Long.valueOf(uprn.getValue()));
   }
@@ -53,5 +59,38 @@ public class UniquePropertyReferenceNumberTest {
     Dto deser = deserialise(json, Dto.class);
     assertEquals(A_UPRN, deser.getUprn());
     assertEquals(ANOTHER_UPRN, deser.getAnotherUprn());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testUprnMinFail() {
+    new UniquePropertyReferenceNumber(UPRN_MIN_FAIL);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testUprnMaxFail() {
+    new UniquePropertyReferenceNumber(UPRN_MAX_FAIL);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testUprnConversionFail() {
+    new UniquePropertyReferenceNumber(UPRN_CONVERSION_FAIL);
+  }
+
+  @Test
+  public void testUprnEmptyString() {
+    UniquePropertyReferenceNumber uprn = new UniquePropertyReferenceNumber("");
+    assertEquals(UPRN_DEFAULT_VALUE, uprn.getValue());
+  }
+
+  @Test
+  public void testUprnNull() {
+    UniquePropertyReferenceNumber uprn = new UniquePropertyReferenceNumber(null);
+    assertEquals(UPRN_DEFAULT_VALUE, uprn.getValue());
+  }
+
+  @Test
+  public void testUprnWhiteSpace() {
+    UniquePropertyReferenceNumber uprn = new UniquePropertyReferenceNumber("  ");
+    assertEquals(UPRN_DEFAULT_VALUE, uprn.getValue());
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/common/domain/UniquePropertyReferenceNumberTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/domain/UniquePropertyReferenceNumberTest.java
@@ -8,7 +8,7 @@ import lombok.SneakyThrows;
 import org.junit.Test;
 
 public class UniquePropertyReferenceNumberTest {
-  private static final String UPRN_STR = "334111111111";
+  private static final String UPRN_STR = "3341111111111";
   private static final UniquePropertyReferenceNumber A_UPRN =
       new UniquePropertyReferenceNumber(UPRN_STR);
   private static final UniquePropertyReferenceNumber ANOTHER_UPRN =


### PR DESCRIPTION
# Motivation and Context
UPRNs generated for skeleton cases by RM have an additional leading digit, needing to allow for 13 digits.

# What has changed
UniquePropertyReferenceNumber maximum value extended to 13 digits. As an increase in permitted values may safely be incorporated as non-breaking change in other projects.

# How to test?
Unit test adjusted with 13 rather than 12 digit value.
