### PR TITLE
Cr 1062 improve json validation error messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.integration.common</groupId>
   <artifactId>framework</artifactId>
-  <version>0.0.63-SNAPSHOT</version>
+  <version>0.0.63-CR1062-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : Integration Common Framework</name>

--- a/src/main/java/uk/gov/ons/ctp/common/error/RestExceptionHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/common/error/RestExceptionHandler.java
@@ -286,7 +286,7 @@ public class RestExceptionHandler {
   public ResponseEntity<?> handleHttpMessageNotReadableException(
       HttpMessageNotReadableException ex) {
     log.error("Uncaught HttpMessageNotReadableException", ex);
-    String message = createErrorMessage(ex);
+    String message = createCleanedUpErrorMessage(ex);
 
     CTPException ourException = new CTPException(CTPException.Fault.VALIDATION_FAILED, message);
 
@@ -307,11 +307,20 @@ public class RestExceptionHandler {
     log.with("parameter", ex.getParameter().getParameterName())
         .warn("Uncaught MethodArgumentNotValidException", ex);
     CTPException ourException =
-        new CTPException(CTPException.Fault.VALIDATION_FAILED, createErrorMessage(ex));
+        new CTPException(CTPException.Fault.VALIDATION_FAILED, createCleanedUpErrorMessage(ex));
     return new ResponseEntity<>(ourException, HttpStatus.BAD_REQUEST);
   }
 
-  private String createErrorMessage(Exception ex) {
+  /**
+   * This method creates explanatory response text for an exception. It cleans up the exception
+   * message and attempts to provide a concise reason for the error without internal class names or
+   * error repetition.
+   *
+   * @param ex is the exception to create a message for.
+   * @return a String with simplified error text, or if it doesn't fit an existing pattern an error
+   *     string with the exceptions message text.
+   */
+  private String createCleanedUpErrorMessage(Exception ex) {
     // By default we return the message text, unless we can scrape out a better explanation
     String messageDetail = ex.getMessage();
 

--- a/src/main/java/uk/gov/ons/ctp/common/error/RestExceptionHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/common/error/RestExceptionHandler.java
@@ -307,9 +307,8 @@ public class RestExceptionHandler {
     String message = createCleanedUpErrorMessage(ex);
     log.with("parameter", ex.getParameter().getParameterName())
         .info("Uncaught MethodArgumentNotValidException. " + message);
-    
-    CTPException ourException =
-        new CTPException(CTPException.Fault.VALIDATION_FAILED, message);
+
+    CTPException ourException = new CTPException(CTPException.Fault.VALIDATION_FAILED, message);
     return new ResponseEntity<>(ourException, HttpStatus.BAD_REQUEST);
   }
 

--- a/src/main/java/uk/gov/ons/ctp/common/error/RestExceptionHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/common/error/RestExceptionHandler.java
@@ -327,7 +327,7 @@ public class RestExceptionHandler {
         break;
       }
     }
-    
+
     return PROVIDED_JSON_INCORRECT + " Caused by: " + messageDetail.trim();
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/common/error/RestExceptionHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/common/error/RestExceptionHandler.java
@@ -285,8 +285,8 @@ public class RestExceptionHandler {
   @ExceptionHandler(HttpMessageNotReadableException.class)
   public ResponseEntity<?> handleHttpMessageNotReadableException(
       HttpMessageNotReadableException ex) {
-    log.error("Uncaught HttpMessageNotReadableException", ex);
     String message = createCleanedUpErrorMessage(ex);
+    log.info("Uncaught HttpMessageNotReadableException. " + message);
 
     CTPException ourException = new CTPException(CTPException.Fault.VALIDATION_FAILED, message);
 
@@ -304,10 +304,12 @@ public class RestExceptionHandler {
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<?> handleMethodArgumentNotValidException(
       MethodArgumentNotValidException ex) {
+    String message = createCleanedUpErrorMessage(ex);
     log.with("parameter", ex.getParameter().getParameterName())
-        .warn("Uncaught MethodArgumentNotValidException", ex);
+        .info("Uncaught MethodArgumentNotValidException. " + message);
+    
     CTPException ourException =
-        new CTPException(CTPException.Fault.VALIDATION_FAILED, createCleanedUpErrorMessage(ex));
+        new CTPException(CTPException.Fault.VALIDATION_FAILED, message);
     return new ResponseEntity<>(ourException, HttpStatus.BAD_REQUEST);
   }
 


### PR DESCRIPTION
This changes creates error response strings which describe the reason why we believe a Json based request is incorrectly formatted. 
Serco currently get responses saying 'Provided JSON fails validation' and the aim 1062 is to explain why their Json has been rejected.

The basic approach is to scrape the key content from the current exception message. This removes internal class names and the duplication which seems to always be present.

See CR-1062 for examples of the responses produced for different Json formatting errors.