### PR TITLE
Cr 1279 add support for too many requests to posts

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/error/CTPException.java
+++ b/src/main/java/uk/gov/ons/ctp/common/error/CTPException.java
@@ -38,6 +38,8 @@ public class CTPException extends Exception {
     ACCESS_DENIED,
     /** For bad requests */
     BAD_REQUEST,
+    /** 429 error for overloaded service */
+    TOO_MANY_REQUESTS,
     /** For operations in progress */
     ACCEPTED_UNABLE_TO_PROCESS;
   }

--- a/src/main/java/uk/gov/ons/ctp/common/error/RestExceptionHandler.java
+++ b/src/main/java/uk/gov/ons/ctp/common/error/RestExceptionHandler.java
@@ -92,6 +92,9 @@ public class RestExceptionHandler {
       case VALIDATION_FAILED:
         status = HttpStatus.BAD_REQUEST;
         break;
+      case TOO_MANY_REQUESTS:
+        status = HttpStatus.TOO_MANY_REQUESTS;
+        break;
       case SYSTEM_ERROR:
         status = HttpStatus.INTERNAL_SERVER_ERROR;
         break;
@@ -119,6 +122,9 @@ public class RestExceptionHandler {
         break;
       case BAD_REQUEST:
         fault = Fault.BAD_REQUEST;
+        break;
+      case TOO_MANY_REQUESTS:
+        fault = Fault.TOO_MANY_REQUESTS;
         break;
       case INTERNAL_SERVER_ERROR:
         fault = Fault.SYSTEM_ERROR;

--- a/src/main/java/uk/gov/ons/ctp/common/rest/RestClient.java
+++ b/src/main/java/uk/gov/ons/ctp/common/rest/RestClient.java
@@ -162,7 +162,7 @@ public class RestClient {
    *     K:"haircolor",V:"blond" AND K:"shoesize", V:"9","10"
    * @param pathParams vargs list of params to substitute in the path - note simply used in order
    * @return the type you asked for! or null
-   * @throws ResponseStatusException something went wrong making http call
+   * @throws ResponseStatusException something went wrong making http call. The reason field will contain the http response body.
    */
   @SuppressWarnings("unchecked")
   private <T, O> T doHttpOperation(
@@ -195,11 +195,14 @@ public class RestClient {
               + "'";
       if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
         log.warn(errorMessage, e);
+      } else if (e.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+        // Caller expected to handle this situation
+        log.info("Too many requests response on {} for path: {}", method.name(), path);
       } else {
         log.error(errorMessage, e);
       }
       throw new ResponseStatusException(
-          mapToExternalStatus(e.getStatusCode()), "Unsuccessful response code", e);
+          mapToExternalStatus(e.getStatusCode()), e.getResponseBodyAsString(), e);
     } catch (RestClientException e) {
       log.error(method.name() + " failed for path: '" + uriComponents + "'", e);
       throw new ResponseStatusException(

--- a/src/test/java/uk/gov/ons/ctp/common/error/RestExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/error/RestExceptionHandlerTest.java
@@ -113,6 +113,19 @@ public class RestExceptionHandlerTest {
   }
 
   @Test
+  public void handleCTPException_TOO_MANY_REQUESTS() throws Exception {
+    Mockito.doThrow(new CTPException(Fault.TOO_MANY_REQUESTS)).when(testController).runTest();
+
+    MockHttpServletResponse response =
+        mockMvc
+            .perform(get("/test/run"))
+            .andExpect(status().isTooManyRequests())
+            .andReturn()
+            .getResponse();
+    assertTrue(response.getContentAsString().contains(Fault.TOO_MANY_REQUESTS.toString()));
+  }
+
+  @Test
   public void handleCTPException_SYSTEM_ERROR() throws Exception {
     Mockito.doThrow(new CTPException(Fault.SYSTEM_ERROR)).when(testController).runTest();
 
@@ -198,6 +211,21 @@ public class RestExceptionHandlerTest {
             .andReturn()
             .getResponse();
     assertTrue(response.getContentAsString().contains(Fault.BAD_REQUEST.toString()));
+  }
+
+  @Test
+  public void handleResponseStatusException_TOO_MANY_REQUESTS() throws Exception {
+    Mockito.doThrow(new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS))
+        .when(testController)
+        .runTest();
+
+    MockHttpServletResponse response =
+        mockMvc
+            .perform(get("/test/run"))
+            .andExpect(status().isTooManyRequests())
+            .andReturn()
+            .getResponse();
+    assertTrue(response.getContentAsString().contains(Fault.TOO_MANY_REQUESTS.toString()));
   }
 
   @Test


### PR DESCRIPTION
This change extends the RestClient to support the TOO_MANY_REQUESTS requirements when calling the rate limiter. It allows the rate limiter client to throw an exception which RHSvc can use to report back to the UI that we got a 429 (too many requests).

Key changes:

- Merged the get/put/post methods so that the put/post get the same exception handling.
- Added a TOO_MANY_REQUESTS fault code.
- Unit tests updated to reflect the above.