### PR TITLE
CR-1772 Allowing RESOURCE_EXHAUSTED status when Firestore is overloaded

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.integration.common</groupId>
   <artifactId>framework</artifactId>
-  <version>0.0.74-SNAPSHOT</version>
+  <version>0.0.74-CR1772-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : Integration Common Framework</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.integration.common</groupId>
   <artifactId>framework</artifactId>
-  <version>0.0.74-CR1772-SNAPSHOT</version>
+  <version>0.0.74-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : Integration Common Framework</name>

--- a/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
+++ b/src/main/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStore.java
@@ -111,7 +111,8 @@ public class FirestoreDataStore implements CloudDataStore {
         StatusRuntimeException statusRuntimeException = (StatusRuntimeException) t;
         Code failureCode = statusRuntimeException.getStatus().getCode();
 
-        if (failureCode == Status.ABORTED.getCode()
+        if (failureCode == Status.RESOURCE_EXHAUSTED.getCode()
+            || failureCode == Status.ABORTED.getCode()
             || failureCode == Status.DEADLINE_EXCEEDED.getCode()
             || failureCode == Status.UNAVAILABLE.getCode()) {
           retryable = true;

--- a/src/test/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStoreTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/cloud/FirestoreDataStoreTest.java
@@ -76,9 +76,18 @@ public class FirestoreDataStoreTest extends CloudTestBase {
   }
 
   @Test
-  public void testStoreObject_detectsContention() throws Exception {
+  public void testStoreObject_detectsContentionForResourceExhausted() throws Exception {
+    doTestStoreObject_detectsContention(Status.RESOURCE_EXHAUSTED);
+  }
+
+  @Test
+  public void testStoreObject_detectsContentionForAborted() throws Exception {
+    doTestStoreObject_detectsContention(Status.ABORTED);
+  }
+
+  public void doTestStoreObject_detectsContention(Status status) throws Exception {
     // Build chain of exceptions as per Firestore
-    Exception rootCauseException = new StatusRuntimeException(Status.ABORTED);
+    Exception rootCauseException = new StatusRuntimeException(status);
     Exception causeException = new RuntimeException("e2", rootCauseException);
     Exception firestoreException =
         new java.util.concurrent.ExecutionException("e3", causeException);


### PR DESCRIPTION
RHSVC failed to detect a retryable exception because Firestore now use a different status code to indicate the failure.
This RH log entry shows that Firestore is using the RESOURCE_EXHAUSTED status:
`Status code: "RESOURCE_EXHAUSTED"    
   ...
  }
  event: "StatusRuntimeException found in exception heirarchy, but it's not a retryable code" 
`
Hence the fix is to add this to the list of status codes that trigger the Firestore retry logic